### PR TITLE
bump pddl-validator to 2.1.1 for pddl-pyvalidator 0.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -30,7 +30,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/plugins/pddl-validator/.claude-plugin/plugin.json
+++ b/plugins/pddl-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Validate PDDL domains, problems, and plans — check syntax, verify plan correctness, and inspect state transitions. Pure pip install, no Docker.",
   "author": {
     "name": "SPL-BGU"

--- a/plugins/pddl-validator/CHANGELOG.md
+++ b/plugins/pddl-validator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+- Bump `pddl-pyvalidator` to `>=0.1.4` to pick up the numeric-goal evaluation fix. Prior versions reported plans as `INVALID` whenever the goal contained a numeric comparison (`<=`, `>=`, `=`), affecting domains like `counters` and `farmland`. Boolean-goal domains were unaffected. No plugin API changes.
+
 ## 2.1.0
 
 - New `verbose` parameter on `validate_pddl_syntax` (default `True`) — when `False`, the response drops the heavyweight `details` field. `report` is preserved as the primary human-readable summary.

--- a/plugins/pddl-validator/requirements.txt
+++ b/plugins/pddl-validator/requirements.txt
@@ -1,3 +1,3 @@
 mcp
 pydantic
-pddl-pyvalidator>=0.1.1
+pddl-pyvalidator>=0.1.4


### PR DESCRIPTION
Picks up the upstream numeric-goal evaluation fix. Prior pyvalidator releases reported plans as INVALID whenever the goal contained a numeric comparison (<=, >=, =), affecting counters/farmland and any domain with a numeric goal; boolean-goal domains were unaffected. No plugin API change — just a dependency pin and version bump, ready to merge once pddl-pyvalidator 0.1.4 ships to PyPI.