### PR TITLE
redirect uv venv/pip install to stderr in launch scripts

### DIFF
--- a/plugins/pddl-parser/scripts/launch-server.sh
+++ b/plugins/pddl-parser/scripts/launch-server.sh
@@ -9,8 +9,8 @@ SERVER="$PLUGIN_DIR/server/parser_server.py"
 if [ ! -d "$VENV_DIR" ]; then
     echo "[pddl-parser] Setting up Python environment..." >&2
     if command -v uv &>/dev/null; then
-        uv venv "$VENV_DIR"
-        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt"
+        uv venv "$VENV_DIR" >&2
+        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt" >&2
     else
         python3 -m venv "$VENV_DIR"
         "$VENV_DIR/bin/pip" install --quiet -r "$PLUGIN_DIR/requirements.txt"

--- a/plugins/pddl-solver/scripts/launch-server.sh
+++ b/plugins/pddl-solver/scripts/launch-server.sh
@@ -14,8 +14,8 @@ SERVER="$PLUGIN_DIR/server/solver_server.py"
 if [ ! -d "$VENV_DIR" ]; then
     echo "[pddl-solver] Setting up Python environment..." >&2
     if command -v uv &>/dev/null; then
-        uv venv "$VENV_DIR"
-        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt"
+        uv venv "$VENV_DIR" >&2
+        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt" >&2
     else
         python3 -m venv "$VENV_DIR"
         "$VENV_DIR/bin/pip" install --quiet -r "$PLUGIN_DIR/requirements.txt"

--- a/plugins/pddl-validator/scripts/launch-server.sh
+++ b/plugins/pddl-validator/scripts/launch-server.sh
@@ -14,8 +14,8 @@ SERVER="$PLUGIN_DIR/server/validator_server.py"
 if [ ! -d "$VENV_DIR" ]; then
     echo "[pddl-validator] Setting up Python environment..." >&2
     if command -v uv &>/dev/null; then
-        uv venv "$VENV_DIR"
-        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt"
+        uv venv "$VENV_DIR" >&2
+        uv pip install --python "$VENV_DIR/bin/python3" -r "$PLUGIN_DIR/requirements.txt" >&2
     else
         python3 -m venv "$VENV_DIR"
         "$VENV_DIR/bin/pip" install --quiet -r "$PLUGIN_DIR/requirements.txt"


### PR DESCRIPTION
Under MCP stdio transport, stdout is the JSON-RPC channel. On cold start (no .venv present), uv's bright-cyan progress text leaked to stdout and broke the client-side JSONRPCMessage parser with:
  Invalid JSON: expected value at line 1 column 1
  input_value='\x1b[0m\x1b[96m...'

Only reproduced where .venv was missing (e.g., BGU Slurm jobs) — local machines with a warm venv skip the install branch entirely.

Fix: append >&2 to `uv venv` and `uv pip install` in all three launch-server.sh scripts. Fallback branch (python3 -m venv + pip --quiet) already produces no stdout. set -euo pipefail still catches uv failures.