### PR TITLE
silence unified_planning credits banner to unpollute MCP stdio

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "source": "./plugins/pddl-solver",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "source": "./plugins/pddl-solver",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/plugins/pddl-solver/.claude-plugin/plugin.json
+++ b/plugins/pddl-solver/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-solver",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Solve PDDL planning problems — supports classical and numeric (PDDL 2.1) domains. Pure pip install, no Docker.",
   "author": {
     "name": "SPL-BGU"

--- a/plugins/pddl-solver/server/solver_server.py
+++ b/plugins/pddl-solver/server/solver_server.py
@@ -15,8 +15,12 @@ import time
 import uuid
 
 from unified_planning.io import PDDLReader
-from unified_planning.shortcuts import OneshotPlanner
+from unified_planning.shortcuts import OneshotPlanner, get_environment
 import unified_planning.engines.results as up_results
+
+# Silence the UP factory credits banner — it writes ANSI-coloured text to
+# sys.stdout, which corrupts the MCP stdio JSONRPC channel on the client.
+get_environment().credits_stream = None
 
 mcp = FastMCP("pddl-solver")
 

--- a/plugins/pddl-solver/tests/verify.sh
+++ b/plugins/pddl-solver/tests/verify.sh
@@ -182,6 +182,21 @@ def test_env_var_invalid_raises():
     assert "ValueError" in rc.stderr, f"Expected ValueError, got: {rc.stderr.strip()}"
 test("env-var invalid int raises ValueError naming the var", test_env_var_invalid_raises)
 
+def test_no_stdout_pollution():
+    # Regression: unified_planning.engines.factory writes a credits banner to
+    # sys.stdout by default, which corrupts the MCP stdio JSONRPC channel.
+    # The server suppresses this via get_environment().credits_stream = None.
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        result = classic_planner(DOMAIN, PROBLEM)
+        _ = numeric_planner(NUMERIC_DOMAIN, NUMERIC_PROBLEM)
+    assert "error" not in result, result
+    captured = buf.getvalue()
+    assert captured == "", \
+        f"Planner call wrote to stdout (would corrupt MCP JSONRPC): {captured!r}"
+test("planners leave stdout clean (no MCP pollution)", test_no_stdout_pollution)
+
 def test_classic_planner_no_cwd_pollution():
     # Regression: Fast Downward writes `output.sas` to CWD. The server must pin
     # CWD to its request-scoped temp dir so solves work in read-only envs


### PR DESCRIPTION
The UP engine factory writes an ANSI-coloured credits banner to sys.stdout on every OneshotPlanner call, corrupting the JSONRPC channel for MCP stdio clients. Set credits_stream = None at module load (the fix the banner itself recommends). Covers both Fast Downward and ENHSP via the shared factory. Adds a regression test asserting planner calls leave stdout clean.