### PR TITLE
add pddl-author plugin: pure-skill authoring + iterative fix-loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,20 @@
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
       "category": "planning",
       "keywords": ["pddl", "parser", "trajectory", "state-transition", "introspection", "applicability"]
+    },
+    {
+      "name": "pddl-author",
+      "description": "Author PDDL domains and problems from natural-language descriptions, then iteratively fix them using sibling plugins (validator, parser, solver) as ground truth. Pure skill, no MCP server.",
+      "author": {
+        "name": "SPL-BGU"
+      },
+      "license": "MIT",
+      "version": "0.1.0",
+      "source": "./plugins/pddl-author",
+      "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+      "repository": "https://github.com/SPL-BGU/pddl-copilot",
+      "category": "planning",
+      "keywords": ["pddl", "authoring", "domain-design", "natural-language", "iterative-fix"]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -50,6 +50,20 @@
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
       "category": "planning",
       "keywords": ["pddl", "parser", "trajectory", "state-transition", "introspection", "applicability"]
+    },
+    {
+      "name": "pddl-author",
+      "description": "Author PDDL domains and problems from natural-language descriptions, then iteratively fix them using sibling plugins (validator, parser, solver) as ground truth. Pure skill, no MCP server.",
+      "author": {
+        "name": "SPL-BGU"
+      },
+      "license": "MIT",
+      "version": "0.1.0",
+      "source": "./plugins/pddl-author",
+      "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+      "repository": "https://github.com/SPL-BGU/pddl-copilot",
+      "category": "planning",
+      "keywords": ["pddl", "authoring", "domain-design", "natural-language", "iterative-fix"]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This repository is a Claude Code plugin marketplace. Each plugin lives in its ow
 - **pddl-solver** (`plugins/pddl-solver/`) — PDDL planning using Fast Downward (via up-fast-downward) and ENHSP (via up-enhsp). Pure pip, no Docker.
 - **pddl-validator** (`plugins/pddl-validator/`) — PDDL validation and state transition simulation using pyvalidator. Pure pip, no Docker.
 - **pddl-parser** (`plugins/pddl-parser/`) — PDDL parsing and structured trajectory generation with dual-backend support: pddl-plus-parser (default) and unified-planning. Pure pip, no Docker.
+- **pddl-author** (`plugins/pddl-author/`) — Authoring and iterative-fix skills (no MCP server). Drafts PDDL from NL descriptions and fixes via sibling plugins as ground truth. Pure skill.
 
 ## Ollama MCP Bridge
 

--- a/plugins/pddl-author/.claude-plugin/plugin.json
+++ b/plugins/pddl-author/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pddl-author",
+  "version": "0.1.0",
+  "description": "Author PDDL domains and problems from natural-language descriptions, then iteratively fix them using sibling plugins (validator, parser, solver) as ground truth. Pure skill, no MCP server.",
+  "author": {
+    "name": "SPL-BGU"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+  "repository": "https://github.com/SPL-BGU/pddl-copilot",
+  "keywords": ["pddl", "authoring", "domain-design", "natural-language", "iterative-fix"]
+}

--- a/plugins/pddl-author/CLAUDE.md
+++ b/plugins/pddl-author/CLAUDE.md
@@ -11,7 +11,7 @@ Two skills:
 These skills call MCP tools from sibling plugins. They are **soft dependencies** — the skills detect missing tools and report them to the user rather than failing silently. For full functionality, install:
 
 - `pddl-validator` (required) — `validate_pddl_syntax`, `get_state_transition`
-- `pddl-parser` (required) — `normalize_pddl`, `inspect_domain`, `inspect_problem`, `get_trajectory`
+- `pddl-parser` (required) — `normalize_pddl`, `inspect_domain`, `inspect_problem`, `get_trajectory`, `get_applicable_actions`, `check_applicable`
 - `pddl-solver` (recommended for `pddl-fixing`) — `classic_planner`, `numeric_planner`
 
 The author plugin itself ships zero binaries and zero Python deps.

--- a/plugins/pddl-author/CLAUDE.md
+++ b/plugins/pddl-author/CLAUDE.md
@@ -1,0 +1,22 @@
+# PDDL Author — Plugin Rules
+
+PDDL authoring and iterative fix-loop plugin. Pure skill (no MCP server, no Python deps). Orchestrates the sibling plugins `pddl-validator`, `pddl-parser`, and `pddl-solver` as the source of ground truth — does not import their code.
+
+Two skills:
+- `pddl-authoring` — draft a PDDL domain (and optional problem) from a natural-language description, or revise an existing draft from human feedback.
+- `pddl-fixing` — given a draft domain, an intent description, and at least one anchor problem, iterate fix → parse → validate → plan → trajectory until all checks pass or escalate to human.
+
+## Dependencies (runtime)
+
+These skills call MCP tools from sibling plugins. They are **soft dependencies** — the skills detect missing tools and report them to the user rather than failing silently. For full functionality, install:
+
+- `pddl-validator` (required) — `validate_pddl_syntax`, `get_state_transition`
+- `pddl-parser` (required) — `normalize_pddl`, `inspect_domain`, `inspect_problem`, `get_trajectory`
+- `pddl-solver` (recommended for `pddl-fixing`) — `classic_planner`, `numeric_planner`
+
+The author plugin itself ships zero binaries and zero Python deps.
+
+## Scope boundaries
+
+- **In scope**: drafting PDDL from descriptions, applying human-feedback edits, running an iterative fix-loop against an anchor problem.
+- **Out of scope**: experimentation, benchmarking, or automated evaluation across many domains. Those belong in a separate research project — this repo is functional implementation only.

--- a/plugins/pddl-author/skills/pddl-authoring/SKILL.md
+++ b/plugins/pddl-author/skills/pddl-authoring/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pddl-authoring
+description: Use when the user asks to draft, generate, write, or translate a natural-language description into a PDDL domain or problem from scratch, or to revise an existing PDDL draft based on human feedback (add an action, change a precondition, rename a predicate, etc.). NOT for fixing parser/validator errors — use pddl-fixing for that.
+allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem
+---
+
+## CRITICAL RULES — zero exceptions
+
+### You MUST validate every PDDL file you produce before reporting it as done
+
+After writing or editing a domain or problem:
+1. Call `normalize_pddl(content=...)` to confirm it parses.
+2. Call `validate_pddl_syntax(domain=..., problem=...)` to confirm syntactic + structural validity.
+3. Only report the draft to the user if both succeed.
+4. If either fails: do **not** silently retry forever. Hand off to the `pddl-fixing` skill (tell the user: "syntax errors remain — switching to /pddl-fixing").
+
+### You are NOT a planner and NOT a validator
+
+This skill produces drafts. It does **not** prove correctness. Functional correctness against an intent is the job of `pddl-fixing`. Do not claim a domain "models the description correctly" based on your own reading.
+
+### Do not invent semantics
+
+If the user's description is ambiguous (e.g., "objects can be moved" — by whom? in what state?), ask one clarifying question before authoring. Do not guess at hidden constraints. Better to surface ambiguity than to bake a wrong assumption into preconditions.
+
+## Two entry modes
+
+### Mode A — blank-start authoring
+
+User provides a natural-language description; no prior PDDL exists.
+
+Workflow:
+1. **Restate the domain** in 3–5 bullets: types, predicates you'll introduce, actions, key invariants. Show this to the user.
+2. **Pause for confirmation** unless the user said "just do it" or auto mode is active. Restating catches misunderstandings before code.
+3. **Draft the domain** as a single PDDL string. Use `:requirements` minimally — declare only what you actually use (`:typing`, `:negative-preconditions`, `:numeric-fluents`, etc.).
+4. **Validate**: `normalize_pddl(content=domain)` then `validate_pddl_syntax(domain=domain)`.
+5. **If the user also asked for an example problem**, draft it after the domain validates, then re-validate with both.
+6. **Report**: the draft PDDL plus the validator status. Suggest `/pddl-fixing` if the user wants the fix-loop with planner verification.
+
+### Mode B — feedback-driven revision
+
+User provides existing PDDL plus a description of the change they want.
+
+Workflow:
+1. **Read the current PDDL** (use `inspect_domain` / `inspect_problem` if helpful — gives you grounded actions, types, predicates).
+2. **State the diff in plain language**: "I will add action `unload`, change precondition X of action Y, …". Pause for confirmation if the change is non-trivial (>3 edits, or alters existing action semantics).
+3. **Apply the edit** to the PDDL string. Keep all unrelated code byte-identical — do not "clean up" while editing.
+4. **Validate**: `normalize_pddl` then `validate_pddl_syntax`.
+5. **Report** the new draft plus the validator status.
+
+## Tools you may call
+
+- `normalize_pddl(content, domain?, output_format?)` (pddl-parser) — quick parse check; returns structured JSON or raises a parse error.
+- `validate_pddl_syntax(domain, problem?, plan?, verbose?)` (pddl-validator) — full syntax + structural validation.
+- `inspect_domain(domain, problem?, parser?)` (pddl-parser) — read-only structure of an existing draft (actions, predicates, types).
+- `inspect_problem(domain, problem, parser?)` (pddl-parser) — read-only structure of an existing problem.
+
+You may pass either inline PDDL strings or absolute file paths to all of these.
+
+## What you MUST NOT do
+
+- Do NOT skip validation. A draft that hasn't passed `validate_pddl_syntax` is not a draft — it's a guess.
+- Do NOT call planners (`classic_planner` / `numeric_planner`) from this skill. Planning is the fix-loop's job.
+- Do NOT auto-fix repeatedly without bound. After one validate-fix cycle, if errors remain, hand off to `pddl-fixing` and tell the user.
+- Do NOT add `:requirements` you don't use. Each requirement implies a feature; redundant ones confuse downstream tools.
+
+## If a sibling plugin's tool is missing
+
+If `validate_pddl_syntax` or `normalize_pddl` is not available (the user did not install pddl-validator / pddl-parser), do not silently produce unvalidated PDDL. Tell the user:
+
+> "I drafted the PDDL but cannot validate it because `pddl-validator` / `pddl-parser` is not installed. Install them and re-run, or accept the draft as unverified."
+
+## Output format
+
+Always return:
+1. The full PDDL content (domain, and problem if requested), in fenced code blocks.
+2. A short status line: `Validation: PASSED` / `Validation: FAILED — see report below` / `Validation: SKIPPED — pddl-validator not installed`.
+3. Suggested next step (e.g., `/pddl-fixing` if validation passed but the user wants a planner-backed correctness check).

--- a/plugins/pddl-author/skills/pddl-authoring/SKILL.md
+++ b/plugins/pddl-author/skills/pddl-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pddl-authoring
 description: Use when the user asks to draft, generate, write, or translate a natural-language description into a PDDL domain or problem from scratch, or to revise an existing PDDL draft based on human feedback (add an action, change a precondition, rename a predicate, etc.). NOT for fixing parser/validator errors — use pddl-fixing for that.
-allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem
+allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem, mcp__pddl-parser__get_applicable_actions, mcp__pddl-parser__check_applicable
 ---
 
 ## CRITICAL RULES — zero exceptions
@@ -20,7 +20,7 @@ This skill produces drafts. It does **not** prove correctness. Functional correc
 
 ### Do not invent semantics
 
-If the user's description is ambiguous (e.g., "objects can be moved" — by whom? in what state?), ask one clarifying question before authoring. Do not guess at hidden constraints. Better to surface ambiguity than to bake a wrong assumption into preconditions.
+The intent contract (see Mode A step 1) is your defense against guessing. If the user's description is ambiguous (e.g., "objects can be moved" — by whom? in what state?), the ambiguity should appear as a flagged or guessed cell in the contract — surface it there rather than baking a wrong assumption into preconditions. If a guessed cell remains after the user reviews the contract, ask one clarifying question before drafting PDDL.
 
 ## Two entry modes
 
@@ -29,23 +29,35 @@ If the user's description is ambiguous (e.g., "objects can be moved" — by whom
 User provides a natural-language description; no prior PDDL exists.
 
 Workflow:
-1. **Restate the domain** in 3–5 bullets: types, predicates you'll introduce, actions, key invariants. Show this to the user.
-2. **Pause for confirmation** unless the user said "just do it" or auto mode is active. Restating catches misunderstandings before code.
-3. **Draft the domain** as a single PDDL string. Use `:requirements` minimally — declare only what you actually use (`:typing`, `:negative-preconditions`, `:numeric-fluents`, etc.).
-4. **Validate**: `normalize_pddl(content=domain)` then `validate_pddl_syntax(domain=domain)`.
-5. **If the user also asked for an example problem**, draft it after the domain validates, then re-validate with both.
-6. **Report**: the draft PDDL plus the validator status. Suggest `/pddl-fixing` if the user wants the fix-loop with planner verification.
+1. **Build the intent contract** — propose a structured table the user can audit cell-by-cell:
+   - **Types** — name → one-line meaning
+   - **Predicates** — `(name ?args)` → one-line meaning
+   - **Numeric fluents** (only if needed)
+   - **Actions** — `name | params | when-can-fire (preconditions in plain words) | what-changes (effects in plain words)`
+   - **Invariants** — properties that must always hold
+   - **Forbidden behaviors** — things the user expects to NOT be possible
+   - **Intent scenarios** — at least one POSITIVE ("from state X a plan must reach Y") and one NEGATIVE ("from state X no plan should exist") that pin down intent as falsifiable predicates. These also seed `/pddl-fixing`.
+2. **Pause for confirmation** unless the user said "just do it" or auto mode is active. Even in auto mode, always *show* the contract so the user can interrupt — the user accepts, edits, or corrects cells in one turn, never a multi-question interview.
+3. **Draft the domain** as a single PDDL string. Mirror the contract: every action's precondition/effect comes from its row in the action table. Use `:requirements` minimally — declare only what you actually use (`:typing`, `:negative-preconditions`, `:numeric-fluents`, etc.).
+4. **Validate syntax**: `normalize_pddl(content=domain)` then `validate_pddl_syntax(domain=domain)`.
+5. **Tool-grounded intent verification** (strongly recommended; requires a tiny example problem):
+   - If the user did not supply a problem, draft one that exercises the positive and negative scenarios and ask them to confirm it represents intent before treating it as ground truth.
+   - Call `inspect_domain(domain, problem)` — confirm grounded action signatures match the contract's action table.
+   - Call `get_applicable_actions(domain, problem, "initial")` — show the user the legal moves from the initial state and ask "does this match your intuition?" Surface any surprises (an action firing when the contract said it shouldn't, or a missing action the contract expected).
+   - For each forbidden behavior: construct the smallest state where the forbidden action *would* fire if the domain were broken; call `check_applicable(...)` and confirm the result is "not applicable."
+6. **Report**: the contract, the draft PDDL (and problem, if drafted), validator status, and the tool-verification verdicts (matched / surprises). Suggest `/pddl-fixing` to run the planner against the positive and negative scenarios.
 
 ### Mode B — feedback-driven revision
 
 User provides existing PDDL plus a description of the change they want.
 
 Workflow:
-1. **Read the current PDDL** (use `inspect_domain` / `inspect_problem` if helpful — gives you grounded actions, types, predicates).
-2. **State the diff in plain language**: "I will add action `unload`, change precondition X of action Y, …". Pause for confirmation if the change is non-trivial (>3 edits, or alters existing action semantics).
+1. **Project the current PDDL into the intent contract**: call `inspect_domain` (and `inspect_problem` if a problem is available), then render the same table format from Mode A — types, predicates, actions, invariants. This is the baseline.
+2. **State the proposed delta as a contract diff** — show only the cells changing (or the rows being added / removed). Pause for confirmation if the change is non-trivial (>3 cell changes, or alters existing action semantics). For renames-only, no confirmation needed.
 3. **Apply the edit** to the PDDL string. Keep all unrelated code byte-identical — do not "clean up" while editing.
-4. **Validate**: `normalize_pddl` then `validate_pddl_syntax`.
-5. **Report** the new draft plus the validator status.
+4. **Validate syntax**: `normalize_pddl` then `validate_pddl_syntax`.
+5. **Tool-grounded re-verification** (if a problem is available): call `inspect_domain` again to confirm the new grounded signatures match the updated contract; spot-check applicability on at least one scenario the user named.
+6. **Report** the contract diff, the new draft, and the validator status.
 
 ## Tools you may call
 
@@ -53,8 +65,35 @@ Workflow:
 - `validate_pddl_syntax(domain, problem?, plan?, verbose?)` (pddl-validator) — full syntax + structural validation.
 - `inspect_domain(domain, problem?, parser?)` (pddl-parser) — read-only structure of an existing draft (actions, predicates, types).
 - `inspect_problem(domain, problem, parser?)` (pddl-parser) — read-only structure of an existing problem.
+- `get_applicable_actions(domain, problem, state?, max_results?, parser?)` (pddl-parser) — list legal moves from a state. Used in Mode A step 5 to show the user what the domain actually permits from the initial state.
+- `check_applicable(domain, problem, state, action, parser?)` (pddl-parser) — test whether a specific action fires in a specific state. Used in Mode A step 5 to verify that forbidden behaviors are forbidden.
 
 You may pass either inline PDDL strings or absolute file paths to all of these.
+
+## Worked example (Mode A, compressed)
+
+User: *"I want a domain where a truck delivers packages between locations connected by direct routes."*
+
+LLM proposes the contract:
+
+| section | content |
+|---|---|
+| types | `truck`, `location`, `package` |
+| predicates | `(at ?x ?l)` — object x is at location l. `(in ?p ?t)` — p loaded in t. `(connected ?l1 ?l2)` — direct route. |
+| actions | `load(?p ?t ?l)`: truck and package both at l → adds `(in p t)`, removes `(at p l)`. `unload(?p ?t ?l)`: truck at l, p in truck → adds `(at p l)`, removes `(in p t)`. `drive(?t ?l1 ?l2)`: truck at l1, l1 connected to l2 → adds `(at t l2)`, removes `(at t l1)`. |
+| invariants | a package is at exactly one location OR in exactly one truck — never both, never neither. |
+| forbidden | trucks cannot teleport (drive requires `connected`); packages cannot move on their own. |
+| scenarios | **POS**: t1 at A, p1 at A, A connected to B → plan must reach `(at p1 B)`. **NEG**: same setup but no `(connected A B)` → no plan should exist. |
+
+User: *"looks right — but rename `connected` to `road-between` and make it symmetric in init (both directions)."*
+
+LLM updates the contract (one cell changed), drafts the PDDL, runs `normalize_pddl` + `validate_pddl_syntax` (PASSED), then:
+
+- `inspect_domain` → grounded signatures match the action table.
+- `get_applicable_actions(state="initial")` → returns `(drive t1 A B)`, `(load p1 t1 A)`. Matches expectation.
+- `check_applicable((drive t1 A B), state without (road-between A B))` → not applicable. Forbidden behavior holds.
+
+LLM reports the contract, the PDDL, `Validation: PASSED`, all verdicts matched, the scenarios — and suggests `/pddl-fixing` for full planner-backed verification.
 
 ## What you MUST NOT do
 
@@ -72,6 +111,9 @@ If `validate_pddl_syntax` or `normalize_pddl` is not available (the user did not
 ## Output format
 
 Always return:
-1. The full PDDL content (domain, and problem if requested), in fenced code blocks.
-2. A short status line: `Validation: PASSED` / `Validation: FAILED — see report below` / `Validation: SKIPPED — pddl-validator not installed`.
-3. Suggested next step (e.g., `/pddl-fixing` if validation passed but the user wants a planner-backed correctness check).
+1. The **intent contract** (Mode A) or the **contract diff** (Mode B), as compact tables.
+2. The full PDDL content (domain, and problem if drafted), in fenced code blocks.
+3. A short status line: `Validation: PASSED` / `Validation: FAILED — see report below` / `Validation: SKIPPED — pddl-validator not installed`.
+4. **Tool-verification verdicts** (one line per check): e.g. `inspect_domain: matched`, `applicable from initial: matched` / `surprise: <action>`, `forbidden behavior <name>: held` / `leaked`.
+5. The intent scenarios in a fenced block, formatted so they can be passed verbatim to `/pddl-fixing`.
+6. Suggested next step (e.g., `/pddl-fixing` to run the planner against the scenarios).

--- a/plugins/pddl-author/skills/pddl-fixing/SKILL.md
+++ b/plugins/pddl-author/skills/pddl-fixing/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pddl-fixing
+description: Use when the user has a draft PDDL domain plus a description of intent and at least one anchor problem to test against, and wants an iterative fix-loop that runs parse → validate-syntax → solve → validate-plan → trajectory-check until all pass or the loop escalates to a human. Use this when /pddl-authoring produced a draft that fails validation, or when the user reports "this domain doesn't behave as I described".
+allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-validator__get_state_transition, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem, mcp__pddl-parser__get_trajectory, mcp__pddl-solver__classic_planner, mcp__pddl-solver__numeric_planner
+---
+
+## CRITICAL RULES — zero exceptions
+
+### The anchor problem is the ground truth
+
+This skill **requires** at least one problem file (or inline PDDL) that represents a known scenario the user expects the domain to solve. Without it, you have no functional ground truth and cannot prove the domain models the description.
+
+If the user has not provided an anchor problem:
+1. Ask for one. A small problem (3–5 objects, single goal) is enough.
+2. If the user cannot provide one, offer to draft one from their description, **then pause and ask them to confirm it represents intended behavior** before treating it as ground truth. Do not invent and proceed silently.
+
+### You CANNOT plan, validate, or simulate state in your head
+
+Every check is delegated to a tool. Never "manually verify" a precondition holds, never "trace" a plan mentally. If a tool is unavailable, report that limitation explicitly to the user.
+
+### Stop after 5 iterations
+
+If the loop has not converged after 5 iterations, **stop** and escalate to the user. Report:
+- the latest PDDL,
+- the most recent failure,
+- the diffs you tried,
+- what you suspect the underlying intent mismatch is.
+
+Do not loop forever. Human feedback breaks ambiguity that automation cannot.
+
+## The fix loop
+
+Inputs you must collect before starting:
+- `domain` — the draft PDDL domain (string or path)
+- `description` — the user's natural-language intent
+- `problem` — at least one anchor problem (string or path)
+- `expected_outcome` (optional) — "the planner should find a plan" / "no plan should exist" / "the plan should include action X"
+
+### Iteration steps (run in order, stop on first failure and fix before continuing)
+
+1. **Parse** — `normalize_pddl(content=domain)`. If it fails, the PDDL is malformed; fix syntax based on the error message. Re-run.
+2. **Validate syntax** — `validate_pddl_syntax(domain=domain, problem=problem)`. If `valid=False`, the diagnostic in `report` / `details` tells you what's structurally wrong. Fix and re-run.
+3. **Plan** — choose planner by reading the domain:
+   - has `:functions` / `increase` / `decrease` → `numeric_planner(domain, problem)`
+   - else → `classic_planner(domain, problem)`
+   Then act on the result:
+   - planner returned a plan AND `expected_outcome` is "no plan should exist" → the domain is too permissive; tighten preconditions of the actions in the returned plan.
+   - planner returned no plan AND `expected_outcome` is "a plan should exist" → the domain is too restrictive; loosen preconditions or add a missing action. Use `inspect_domain` and `get_applicable_actions` (if available) to see what's reachable from the initial state.
+   - planner errored → read the error verbatim; usually a domain issue (undeclared predicate, type mismatch).
+4. **Validate the plan** — if a plan was returned: `validate_pddl_syntax(domain=domain, problem=problem, plan=plan)`. This is the strongest functional check: the planner found *something*, but the validator confirms each step's preconditions actually hold under the domain's semantics. If `valid=False`, the planner and validator disagree — almost always a domain bug (effects not modeled symmetrically with preconditions, or a typo in a predicate name). Fix the domain.
+5. **Trajectory check** — `get_trajectory(domain, problem, plan)` and `get_state_transition(domain, problem, plan)`. Compare the final state against the user's `expected_outcome` description. If the plan reaches the goal but does so by exploiting an unintended action, the domain has a semantic bug — flag it to the user before "fixing" silently (this is the case where the loop should escalate).
+6. **Done** — all five steps pass and the trajectory matches intent. Report:
+   - final domain PDDL,
+   - the plan that solved the anchor problem,
+   - the trajectory summary,
+   - which iterations changed what (one-line diff per iteration).
+
+### Recording each iteration
+
+For each iteration, write **one line** in your reply summarizing:
+> `Iter N: failed at step <step>. Diagnosis: <one sentence>. Edit applied: <one sentence>.`
+
+This gives the user a readable audit trail without overwhelming them.
+
+## Tools you may call
+
+- `normalize_pddl` (pddl-parser) — parse check.
+- `validate_pddl_syntax` (pddl-validator) — syntax + plan validation.
+- `inspect_domain`, `inspect_problem` (pddl-parser) — read-only structure.
+- `get_trajectory` (pddl-parser) — step-by-step state-action-state trace.
+- `get_state_transition` (pddl-validator) — alternate trajectory view with precondition diagnostics on failure.
+- `classic_planner` (pddl-solver) — Fast Downward.
+- `numeric_planner` (pddl-solver) — ENHSP. Requires Java 17+.
+
+You may pass either inline PDDL strings or absolute file paths to all of these.
+
+## What you MUST NOT do
+
+- Do NOT proceed without an anchor problem. Ask first.
+- Do NOT alter the anchor problem mid-loop to make a buggy domain "pass". The anchor is fixed; only the domain changes (unless the user explicitly says the problem itself is wrong).
+- Do NOT make multiple unrelated edits in one iteration — fix one diagnosed issue per iteration so the audit trail is meaningful.
+- Do NOT silently exceed 5 iterations. Escalate.
+- Do NOT mark the domain "correct" without the trajectory check confirming the user's described outcome. A plan that the validator accepts but achieves the goal via an unintended pathway is a bug, not a fix.
+
+## If a sibling plugin's tool is missing
+
+This skill **requires** all three sibling plugins (validator, parser, solver). If any is missing:
+- pddl-validator missing → cannot run steps 2, 4, 5 (partial). Report to user; offer to run a degraded loop using only parser + solver.
+- pddl-parser missing → cannot run steps 1, 5 (partial). Report; loop is too weak to be useful — refuse and ask the user to install it.
+- pddl-solver missing → cannot run step 3. The loop becomes a syntax-only check, equivalent to `pddl-authoring`. Tell the user and switch to that skill instead.
+
+## Output format
+
+End the loop with:
+1. Final domain PDDL in a fenced code block.
+2. Anchor problem PDDL (echoed back, unmodified) in a fenced code block.
+3. Plan that solved the anchor problem.
+4. One-line per-iteration audit trail.
+5. Status: `CONVERGED` / `ESCALATED — N iterations exhausted` / `BLOCKED — missing tool: <name>`.

--- a/plugins/pddl-author/skills/pddl-fixing/SKILL.md
+++ b/plugins/pddl-author/skills/pddl-fixing/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: pddl-fixing
 description: Use when the user has a draft PDDL domain plus a description of intent and at least one anchor problem to test against, and wants an iterative fix-loop that runs parse → validate-syntax → solve → validate-plan → trajectory-check until all pass or the loop escalates to a human. Use this when /pddl-authoring produced a draft that fails validation, or when the user reports "this domain doesn't behave as I described".
-allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-validator__get_state_transition, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem, mcp__pddl-parser__get_trajectory, mcp__pddl-solver__classic_planner, mcp__pddl-solver__numeric_planner
+allowed-tools: mcp__pddl-validator__validate_pddl_syntax, mcp__pddl-validator__get_state_transition, mcp__pddl-parser__normalize_pddl, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem, mcp__pddl-parser__get_trajectory, mcp__pddl-parser__get_applicable_actions, mcp__pddl-parser__check_applicable, mcp__pddl-solver__classic_planner, mcp__pddl-solver__numeric_planner
 ---
 
 ## CRITICAL RULES — zero exceptions
 
-### The anchor problem is the ground truth
+### The intent scenarios are the ground truth
 
-This skill **requires** at least one problem file (or inline PDDL) that represents a known scenario the user expects the domain to solve. Without it, you have no functional ground truth and cannot prove the domain models the description.
+This skill **requires** structured intent scenarios — at minimum one POSITIVE scenario (anchor problem + expected goal-reachability) and ideally one or more NEGATIVE scenarios (anchor problem + "no plan should exist" because of an invariant or forbidden behavior). Without scenarios you have no falsifiable predicate for "the domain models the description" — only a free-text description that cannot be checked.
 
-If the user has not provided an anchor problem:
-1. Ask for one. A small problem (3–5 objects, single goal) is enough.
-2. If the user cannot provide one, offer to draft one from their description, **then pause and ask them to confirm it represents intended behavior** before treating it as ground truth. Do not invent and proceed silently.
+If the user has not provided structured scenarios:
+1. Ask for them. The format is: *"given problem P, a plan should / should not exist. If a plan exists it should reach state S (and optionally include action A)."*
+2. If the user used `/pddl-authoring` first, the contract already lists scenarios — pull them in directly.
+3. If the user cannot provide them, offer to draft them from their description, **then pause and ask them to confirm before treating as ground truth**. Do not invent and proceed silently.
+
+Negative scenarios are strongly recommended — they catch over-permissive domains that the planner happily solves but the validator cannot flag as wrong.
 
 ### You CANNOT plan, validate, or simulate state in your head
 
@@ -32,27 +35,29 @@ Do not loop forever. Human feedback breaks ambiguity that automation cannot.
 
 Inputs you must collect before starting:
 - `domain` — the draft PDDL domain (string or path)
-- `description` — the user's natural-language intent
-- `problem` — at least one anchor problem (string or path)
-- `expected_outcome` (optional) — "the planner should find a plan" / "no plan should exist" / "the plan should include action X"
+- `intent_scenarios` — structured (preferably from `/pddl-authoring`):
+  - **POSITIVE**: anchor problem + expected outcome ("a plan must exist", optionally "must reach state S" or "must include action X").
+  - **NEGATIVE**: anchor problem where you expect "no plan should exist" because of an invariant or forbidden behavior.
+  At minimum: one positive scenario with an anchor problem.
+- `description` (optional) — the user's natural-language intent, used only to disambiguate when scenarios conflict or to draft fresh scenarios when the user cannot supply them.
 
 ### Iteration steps (run in order, stop on first failure and fix before continuing)
 
 1. **Parse** — `normalize_pddl(content=domain)`. If it fails, the PDDL is malformed; fix syntax based on the error message. Re-run.
 2. **Validate syntax** — `validate_pddl_syntax(domain=domain, problem=problem)`. If `valid=False`, the diagnostic in `report` / `details` tells you what's structurally wrong. Fix and re-run.
-3. **Plan** — choose planner by reading the domain:
-   - has `:functions` / `increase` / `decrease` → `numeric_planner(domain, problem)`
-   - else → `classic_planner(domain, problem)`
-   Then act on the result:
-   - planner returned a plan AND `expected_outcome` is "no plan should exist" → the domain is too permissive; tighten preconditions of the actions in the returned plan.
-   - planner returned no plan AND `expected_outcome` is "a plan should exist" → the domain is too restrictive; loosen preconditions or add a missing action. Use `inspect_domain` and `get_applicable_actions` (if available) to see what's reachable from the initial state.
-   - planner errored → read the error verbatim; usually a domain issue (undeclared predicate, type mismatch).
+3. **Plan against each scenario** — for every scenario in `intent_scenarios`, in order:
+   - Choose the planner by reading the domain: has `:functions` / `increase` / `decrease` → `numeric_planner(domain, problem)`; else → `classic_planner(domain, problem)`.
+   - Run it against the scenario's anchor problem and check the verdict against the scenario's expected outcome:
+     - **POSITIVE expected, planner returned no plan** → domain too restrictive. Use `inspect_domain` and `get_applicable_actions` to see what's reachable from the initial state; loosen preconditions or add the missing action.
+     - **NEGATIVE expected, planner returned a plan** → domain too permissive. Tighten preconditions of the actions in the returned plan; the plan that "succeeded" exposes the leaking path.
+     - **Planner errored** → read the error verbatim; usually a domain issue (undeclared predicate, type mismatch).
+   Stop at the **first** failing scenario, fix the diagnosed issue, then restart the loop. Do not chase multiple scenario failures in one edit.
 4. **Validate the plan** — if a plan was returned: `validate_pddl_syntax(domain=domain, problem=problem, plan=plan)`. This is the strongest functional check: the planner found *something*, but the validator confirms each step's preconditions actually hold under the domain's semantics. If `valid=False`, the planner and validator disagree — almost always a domain bug (effects not modeled symmetrically with preconditions, or a typo in a predicate name). Fix the domain.
-5. **Trajectory check** — `get_trajectory(domain, problem, plan)` and `get_state_transition(domain, problem, plan)`. Compare the final state against the user's `expected_outcome` description. If the plan reaches the goal but does so by exploiting an unintended action, the domain has a semantic bug — flag it to the user before "fixing" silently (this is the case where the loop should escalate).
-6. **Done** — all five steps pass and the trajectory matches intent. Report:
+5. **Trajectory check against scenarios** — `get_trajectory(domain, problem, plan)` and `get_state_transition(domain, problem, plan)`. For each POSITIVE scenario, confirm the trajectory's final state satisfies the scenario's expected goal predicates; if the scenario named "must include action X," confirm X appears in the plan. If the plan reaches the goal by using an action that the contract listed as forbidden, the domain has a semantic bug — flag it to the user before "fixing" silently (this is when the loop should escalate to human review).
+6. **Done** — every scenario converges: every POSITIVE yields a valid plan whose trajectory satisfies its expected outcome, and every NEGATIVE yields no plan. Report:
    - final domain PDDL,
-   - the plan that solved the anchor problem,
-   - the trajectory summary,
+   - the plans that solved each positive scenario (and the verdict for each negative scenario),
+   - trajectory summary for at least one positive scenario,
    - which iterations changed what (one-line diff per iteration).
 
 ### Recording each iteration
@@ -67,6 +72,8 @@ This gives the user a readable audit trail without overwhelming them.
 - `normalize_pddl` (pddl-parser) — parse check.
 - `validate_pddl_syntax` (pddl-validator) — syntax + plan validation.
 - `inspect_domain`, `inspect_problem` (pddl-parser) — read-only structure.
+- `get_applicable_actions` (pddl-parser) — list legal moves from a state; useful when diagnosing "domain too restrictive" in step 3.
+- `check_applicable` (pddl-parser) — test a specific action in a specific state; useful for pinpointing which precondition blocks an expected action.
 - `get_trajectory` (pddl-parser) — step-by-step state-action-state trace.
 - `get_state_transition` (pddl-validator) — alternate trajectory view with precondition diagnostics on failure.
 - `classic_planner` (pddl-solver) — Fast Downward.
@@ -76,11 +83,12 @@ You may pass either inline PDDL strings or absolute file paths to all of these.
 
 ## What you MUST NOT do
 
-- Do NOT proceed without an anchor problem. Ask first.
-- Do NOT alter the anchor problem mid-loop to make a buggy domain "pass". The anchor is fixed; only the domain changes (unless the user explicitly says the problem itself is wrong).
+- Do NOT proceed without at least one positive scenario and its anchor problem. Ask first.
+- Do NOT alter scenario problems mid-loop to make a buggy domain "pass". Scenarios are fixed; only the domain changes (unless the user explicitly says the scenario itself is wrong).
 - Do NOT make multiple unrelated edits in one iteration — fix one diagnosed issue per iteration so the audit trail is meaningful.
+- Do NOT cherry-pick scenarios. If you fix scenario A and the edit breaks scenario B, that's a regression — note it in the audit and address both before claiming convergence.
 - Do NOT silently exceed 5 iterations. Escalate.
-- Do NOT mark the domain "correct" without the trajectory check confirming the user's described outcome. A plan that the validator accepts but achieves the goal via an unintended pathway is a bug, not a fix.
+- Do NOT mark the domain "correct" without the trajectory check satisfying every positive scenario AND every negative scenario yielding no plan. A plan that the validator accepts but achieves the goal via an action listed as forbidden in the contract is a bug, not a fix.
 
 ## If a sibling plugin's tool is missing
 
@@ -93,7 +101,7 @@ This skill **requires** all three sibling plugins (validator, parser, solver). I
 
 End the loop with:
 1. Final domain PDDL in a fenced code block.
-2. Anchor problem PDDL (echoed back, unmodified) in a fenced code block.
-3. Plan that solved the anchor problem.
+2. Scenario set: each scenario's problem PDDL echoed back unmodified in a fenced code block, labeled `POSITIVE` / `NEGATIVE`.
+3. For each positive scenario: the plan that solved it. For each negative scenario: the verdict (`no plan exists, as expected` or `LEAKED — plan was: …`).
 4. One-line per-iteration audit trail.
-5. Status: `CONVERGED` / `ESCALATED — N iterations exhausted` / `BLOCKED — missing tool: <name>`.
+5. Status: `CONVERGED` / `ESCALATED — N iterations exhausted` / `BLOCKED — missing tool: <name>` / `REGRESSED — scenario <name> broke at iteration N`.


### PR DESCRIPTION
## Summary

New **pddl-author** plugin (v0.1.0) — pure skill, no MCP server, no Python deps. Ships two skills that orchestrate sibling plugins (validator, parser, solver) without importing their code.

- `pddl-authoring` — draft a PDDL domain (and optional problem) from a natural-language description, or revise an existing draft from human feedback. Validates via `normalize_pddl` + `validate_pddl_syntax` before reporting; hands off to `pddl-fixing` if errors remain.
- `pddl-fixing` — given a draft domain, an intent description, and at least one **anchor problem** as functional ground truth, iterates parse → validate-syntax → solve → validate-plan → trajectory until all pass. Capped at 5 iterations, then escalates to a human.

## Design notes

- Pure-skill (Approach A from brainstorm). No `.mcp.json`, no `tests/verify.sh` — there are no tools to test.
- Skills declare sibling tools in `allowed-tools` but never import their code, preserving plugin isolation.
- Auto-excluded from the Ollama bridge (which keys on `.mcp.json` at `ollama_mcp_bridge.py:44`) and from the MCP-config block of `install_marketplace.sh`, while still being symlinked for skill installation. Verified both gates locally.
- No IPC sample corpus bundled — this repo is functional implementation; evaluation infrastructure lives in a separate research project.
- Registered in both `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` at v0.1.0.

## Test plan

- [ ] Install locally and run `/pddl-authoring` on a small NL description (e.g., "two robots that can pick and drop boxes between rooms"); confirm it produces validated PDDL.
- [ ] Run `/pddl-fixing` on a deliberately broken domain + valid anchor problem; confirm it reports a fix or escalates after 5 iterations.
- [ ] Confirm `python3 ollama_mcp_bridge.py` does not list pddl-author.
- [ ] Confirm `bash install_marketplace.sh --tool cursor` includes pddl-author skill symlinks but excludes it from the MCP config block.