### PR TITLE
tool interface audit fixes: gate validator plan-VALID leak, surface solver env errors, schema cleanups

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PDDL planning and validation tools for Claude Code",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "source": "./plugins/pddl-solver",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -29,7 +29,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -43,7 +43,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "source": "./plugins/pddl-parser",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PDDL planning tools marketplace",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
@@ -16,7 +16,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "source": "./plugins/pddl-solver",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -30,7 +30,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -44,7 +44,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "source": "./plugins/pddl-parser",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -30,7 +30,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -1,0 +1,93 @@
+# Breaking Changes — Plugin Interface Migration Log
+
+This document records every interface change in the pddl-copilot plugins that
+may affect downstream consumers — most notably the
+[`pddl-copilot-experiments`](https://github.com/SPL-BGU/pddl-copilot-experiments)
+framework, which pins plugin behavior via its MCP bridge (`pddl_eval/chat.py`).
+
+Each entry names the affected tool, the version that introduced the change,
+the nature of the change (`fix` / `additive` / `breaking`), and the
+migration step required in consuming code (if any). Add an entry here whenever
+a plugin makes a user-visible interface change. Run the experiments-repo
+validator (see `tests/` in that repo) after merging any `fix` or `breaking`
+entry to confirm the bridge still parses responses correctly.
+
+---
+
+## 2026-05-18 — Tool interface audit fixes
+
+Marketplace `1.2.0 → 1.3.0`. Triggered by the May-2026 tool interface audit.
+
+### pddl-solver `2.1.1 → 2.2.0`
+
+| Tool | Change | Type | Migration |
+|---|---|---|---|
+| `classic_planner`, `numeric_planner` | `INTERNAL_ERROR` / `UNSUPPORTED_PROBLEM` / `INTERMEDIATE` planner statuses now return `{"error": True, "message": str, "status": str, "log": str, "solve_time": float}` instead of `{"plan": [], "note": "Planner ran but did not find a plan.", ...}`. ENHSP without Java surfaces a clear `"Java runtime not found"` message. | **fix (behavior change)** | Experiments bridge: `_parse_validation_verdict` is not affected (only reads `valid` from the validator). The scoring layer's `_tool_error_seen` already detects `{"error": True}` correctly (`scoring.py`). No migration required, but verify that no run-correctness logic relied on the old empty-plan-plus-note shape. Confirmed reachable as `FR_TOOL_ERROR`. |
+| `classic_planner`, `numeric_planner` | Status routing unchanged for `UNSOLVABLE_PROVEN` / `UNSOLVABLE_INCOMPLETELY` (still `{"plan": [], "note": "Problem is unsolvable", "solve_time": float}`) and `TIMEOUT` / `MEMOUT` (still `{"error": True, "message": ...}`). | additive | None. |
+| `save_plan` | `plan` parameter typed `list[str]` (was bare `list`). | additive (schema-only) | None. |
+| `save_plan` | Docstring revised. Filename pattern is now correctly documented as `plan_<tag>.solution`, where `<tag>` is `name` (when supplied) or a derived/random fragment. `name` is a tag fragment, not a literal-filename override. Behavior is unchanged from prior versions. | doc-only | None. |
+
+### pddl-validator `2.1.1 → 2.2.0`
+
+| Tool | Change | Type | Migration |
+|---|---|---|---|
+| `validate_pddl_syntax` | When called *without* a plan (domain-only or domain+problem), the `report` text no longer contains the leaked `"Plan is VALID"` / `"Plan is INVALID"` line from pyvalidator's report formatter. The `valid` boolean and `status` are unaffected. | **fix (behavior change)** | If any experiment grepped the `report` string for `"Plan is VALID"` to derive a syntax-check verdict, switch to reading `valid` (which is the canonical signal — `_parse_validation_verdict` already does this). Verified: experiments do NOT grep the report for these markers. |
+| `validate_pddl_syntax`, `get_state_transition` | `plan` accepts `list[str]` in addition to `str` (content) or `str` (path). Empty list = empty plan, used to validate "init already satisfies goal." | additive | None. Existing string callers unaffected. |
+| `validate_pddl_syntax` | Docstring rewrite — three modes now stated explicitly. Tool name retained for backward compatibility (`validate_pddl_syntax` is a heavily-referenced symbol in `pddl-copilot-experiments`). The audit's rename suggestion (`validate_pddl`) was rejected to avoid the cross-repo blast radius. | doc-only | None. |
+
+### pddl-parser `1.4.0 → 1.5.0`
+
+| Tool | Change | Type | Migration |
+|---|---|---|---|
+| All tools | `parser` parameter typed `Literal["pddl-plus-parser", "unified-planning"]` (was free-form `str`). Misspellings now fail at schema validation rather than at the runtime fallback's "Parser not available" check. Valid values unchanged. | breaking (schema) | None for callers passing valid values. Misspelled callers now get a clearer Pydantic validation error. |
+| `normalize_pddl` | `content` parameter now accepts file paths in addition to inline content. Paths are read and dispatched to the same parsing code path. Brings parity with every other tool. | additive | None. |
+| `normalize_pddl` | Response now includes a dedicated `errors: list[str]` field separate from `warnings`. Hard parse failures populate `errors`; `warnings` retains the same message for one release as a backward-compat alias. | additive (with deprecation) | New callers should read `errors` for hard failures and `warnings` for soft issues. Old callers reading only `warnings` continue to work. |
+| `inspect_domain`, `normalize_pddl` | `types` dict no longer contains the implicit `"object": null` root. Both backends drop it. | **fix (response-shape change)** | If a caller iterated `types` and emitted PDDL `:types` from it, the rendered output now omits the redundant `object` declaration. Re-rendering still produces semantically-equivalent PDDL. |
+| `inspect_domain`, `normalize_pddl` | `:requirements` now preserves the order declared in the PDDL source (was alphabetized). | **fix (response-shape change)** | If a caller relied on alphabetical order, switch to explicit `sorted(...)`. Re-rendered PDDL now round-trips the original `:requirements` order. |
+| `get_applicable_actions` | Results are sorted lexicographically before truncation. Truncated subsets are now deterministic across backends and runs. | **fix (response-shape change)** | None unless a caller expected a specific (undefined) prior order. |
+| `get_trajectory` | `plan` accepts `list[str]` in addition to string/path. | additive | None. |
+| `check_applicable`, `get_applicable_actions` | Docstrings now state the closed-world semantic explicitly (predicates not listed in `state` are treated as false). `check_applicable` docstring also clarifies that `would_add`/`would_delete` are returned for diagnosis even when `applicable=false` and are NOT applied. | doc-only | None. |
+
+### Deferred (not in this release)
+
+These audit findings were considered and deliberately deferred — implementing
+them would require cross-repo coordination that exceeds the scope of an
+interface cleanup:
+
+- **Unify state-serialization formats** across `get_trajectory` (Lisp string),
+  `get_state_transition.trajectory` (dict), and
+  `diff_states`/`check_applicable`/`get_applicable_actions` (JSON array of
+  Lisp strings). `get_state_transition.trajectory` is the byte-equality
+  oracle for the experiments `simulate` task
+  (`EXPERIMENTS_FLOW.md:145`); any change requires fixture regeneration.
+  Track as a separate design discussion before any release.
+- **Rename `validate_pddl_syntax` → `validate_pddl`** (or split). Too
+  many references across `pddl-copilot-experiments` (CHANGELOG, scoring,
+  tests, plan docs). Would require a coordinated rename across both repos.
+- **`get_applicable_actions` `hide_no_op` flag.** Optional feature; no
+  consumer has asked for it yet.
+- **`save_plan.name` true filename override.** Audit asked for `name` to
+  drop the `plan_` prefix and `_N` suffix. Behavior is unchanged in this
+  release; only the docstring is corrected to describe what actually
+  happens. Revisit if a user actually needs literal-filename control.
+- **Shrink `validate_pddl_syntax.report` when `verbose=False`.** Audit
+  asked for a one-line summary. Bridge currently passes the report through
+  unmodified; shrinking it changes what experiments log. Defer.
+
+---
+
+## Recipe for adding entries
+
+When you change a plugin's tool interface:
+
+1. Bump the plugin's `version` in its `marketplace.json` entry (both
+   `.claude-plugin/` and `.cursor-plugin/`).
+2. Bump the marketplace `metadata.version` in both files.
+3. Add a row to this document under a new dated section. State the tool,
+   the change, the type (`fix` / `additive` / `breaking` / `doc-only`),
+   and the migration step.
+4. Add a `## <new-version>` entry to the plugin's `CHANGELOG.md`.
+5. Run the affected plugin's `tests/verify.py` to confirm the change.
+6. Dispatch the experiments-repo validator (an agent with `cwd` at
+   `/Users/omereliyahu/personal/pddl-copilot-experiments`) to verify that
+   the experiments framework's bridge and oracles are unaffected.

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -27,11 +27,11 @@ Marketplace `1.2.0 → 1.3.0`. Triggered by the May-2026 tool interface audit.
 | `save_plan` | `plan` parameter typed `list[str]` (was bare `list`). | additive (schema-only) | None. |
 | `save_plan` | Docstring revised. Filename pattern is now correctly documented as `plan_<tag>.solution`, where `<tag>` is `name` (when supplied) or a derived/random fragment. `name` is a tag fragment, not a literal-filename override. Behavior is unchanged from prior versions. | doc-only | None. |
 
-### pddl-validator `2.1.1 → 2.2.0`
+### pddl-validator `2.1.1 → 2.2.1`
 
 | Tool | Change | Type | Migration |
 |---|---|---|---|
-| `validate_pddl_syntax` | When called *without* a plan (domain-only or domain+problem), the `report` text no longer contains the leaked `"Plan is VALID"` / `"Plan is INVALID"` line from pyvalidator's report formatter. The `valid` boolean and `status` are unaffected. | **fix (behavior change)** | If any experiment grepped the `report` string for `"Plan is VALID"` to derive a syntax-check verdict, switch to reading `valid` (which is the canonical signal — `_parse_validation_verdict` already does this). Verified: experiments do NOT grep the report for these markers. |
+| `validate_pddl_syntax` | When called *without* a plan (domain-only or domain+problem), the `report` text no longer contains the leaked `"Plan is VALID"` / `"Plan is INVALID"` line. The actual fix lives upstream in **pyvalidator 0.1.5** ([SPL-BGU/pyvalidator#1](https://github.com/SPL-BGU/pyvalidator/pull/1)) — the formatter's Goal Check block is now gated on `"execution" in result.phases`. Requirements pin bumped to `pddl-pyvalidator>=0.1.5`. The `valid` boolean and `status` are unaffected. | **fix (behavior change, upstream)** | If any experiment grepped the `report` string for `"Plan is VALID"` to derive a syntax-check verdict, switch to reading `valid` (canonical signal — `_parse_validation_verdict` already does this). Verified: experiments do NOT grep the report for these markers. |
 | `validate_pddl_syntax`, `get_state_transition` | `plan` accepts `list[str]` in addition to `str` (content) or `str` (path). Empty list = empty plan, used to validate "init already satisfies goal." | additive | None. Existing string callers unaffected. |
 | `validate_pddl_syntax` | Docstring rewrite — three modes now stated explicitly. Tool name retained for backward compatibility (`validate_pddl_syntax` is a heavily-referenced symbol in `pddl-copilot-experiments`). The audit's rename suggestion (`validate_pddl`) was rejected to avoid the cross-repo blast radius. | doc-only | None. |
 

--- a/ollama_mcp_bridge.py
+++ b/ollama_mcp_bridge.py
@@ -316,7 +316,7 @@ async def main():
         ollama_tools, tool_to_session = await connect_plugins(selected, exit_stack)
 
         if not ollama_tools:
-            print("No tools loaded. Check plugin configuration and Docker status.")
+            print("No tools loaded. Check plugin configuration.")
             sys.exit(1)
 
         print(f"\nTools available ({len(ollama_tools)}):")

--- a/plugins/pddl-parser/CHANGELOG.md
+++ b/plugins/pddl-parser/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.5.0
+
+- `parser` parameter on all tools is now typed `Literal["pddl-plus-parser", "unified-planning"]` (was free-form `str`). Misspellings now fail at schema validation rather than reaching the runtime fallback's "Parser X not available" check. Valid values are unchanged.
+- `normalize_pddl` now accepts file paths in the `content` parameter (was content-only) — paths are read and dispatched to the same code path as inline content. Brings it in line with every other tool in the suite.
+- `normalize_pddl` response now includes a dedicated `errors: list[str]` field separate from `warnings`. Hard parse failures populate `errors`; `warnings` is preserved alongside (still populated with the same message) for backward compatibility — drop `warnings` reliance in new callers.
+- `inspect_domain.types` and `normalize_pddl.normalized.types` no longer include the implicit `"object": null` root. Both backends (`pddl-plus-parser`, `unified-planning`) drop it for consistency.
+- `get_applicable_actions` results are now sorted lexicographically before truncation. Truncated subsets are deterministic across backends and runs (previously, `max_results=50` returned an undocumented order that differed between the two backends).
+- `:requirements` in `inspect_domain` / `normalize_pddl` output now preserve the order declared in the PDDL source (was alphabetized). Reconstructing PDDL from the structured output now round-trips the requirement order.
+- `get_trajectory.plan` now accepts `list[str]` in addition to string/path. An empty list maps to the empty plan.
+- `check_applicable` / `get_applicable_actions` docstrings now state the closed-world semantic explicitly (predicates not listed in `state` are treated as false). `check_applicable` docstring also clarifies that `would_add` / `would_delete` are returned for diagnosis even when `applicable=false` and are NOT applied.
+
 ## 1.4.0
 
 - Env-overridable limits: `PDDL_MAX_GROUNDING_ATTEMPTS` (default 10000) and `PDDL_MAX_APPLICABLE_ACTIONS` (default 50, used as the fallback for `get_applicable_actions.max_results`). Motivated by small-context callers (e.g., Ollama) that truncate large tool responses.

--- a/plugins/pddl-parser/server/backend_pddl_plus.py
+++ b/plugins/pddl-parser/server/backend_pddl_plus.py
@@ -275,7 +275,7 @@ class PddlPlusBackend:
 
         return DomainInfo(
             name=parsed_domain.name,
-            requirements=sorted(parsed_domain.requirements),
+            requirements=list(parsed_domain.requirements),
             types=types_info,
             predicates=predicates_info,
             actions=actions_info,

--- a/plugins/pddl-parser/server/backend_pddl_plus.py
+++ b/plugins/pddl-parser/server/backend_pddl_plus.py
@@ -275,11 +275,17 @@ class PddlPlusBackend:
 
         # pddl-plus-parser stores requirements as a set, losing source order.
         # Re-extract from the source file with regex to preserve declaration order.
+        # Strip ;-to-EOL comments inside the block before splitting so comments
+        # inside (:requirements ...) don't appear as bogus requirement tokens.
         try:
             with open(domain_path, encoding="utf-8") as f:
                 source = f.read()
             m = re.search(r'\(:requirements\s+(.*?)\)', source, re.DOTALL)
-            requirements = m.group(1).split() if m else list(parsed_domain.requirements)
+            if m:
+                req_block = re.sub(r';[^\n]*', '', m.group(1))
+                requirements = req_block.split()
+            else:
+                requirements = list(parsed_domain.requirements)
         except OSError:
             requirements = list(parsed_domain.requirements)
 
@@ -402,7 +408,13 @@ class PddlPlusBackend:
         truncated = False
         grounding_cap_hit = False
 
-        for action in parsed_domain.actions.values():
+        # Enumerate schemas and per-parameter objects in name-sorted order so
+        # itertools.product yields grounded actions in lex order over the
+        # output string. Combined with the early-exit at max_results, this
+        # delivers the lex-smallest N applicable actions deterministically —
+        # and identically to the UP backend (cross-backend reproducibility).
+        sorted_actions = sorted(parsed_domain.actions.values(), key=lambda a: a.name)
+        for action in sorted_actions:
             if len(applicable) >= max_results:
                 truncated = True
                 break
@@ -425,7 +437,7 @@ class PddlPlusBackend:
 
             obj_lists = []
             for ptype in param_types:
-                objs = objects_by_type.get(ptype.name, [])
+                objs = sorted(objects_by_type.get(ptype.name, []))
                 obj_lists.append(objs)
 
             if not all(obj_lists):

--- a/plugins/pddl-parser/server/backend_pddl_plus.py
+++ b/plugins/pddl-parser/server/backend_pddl_plus.py
@@ -273,9 +273,19 @@ class PddlPlusBackend:
                 "effect": compact_pddl(action.effects_to_pddl()),
             })
 
+        # pddl-plus-parser stores requirements as a set, losing source order.
+        # Re-extract from the source file with regex to preserve declaration order.
+        try:
+            with open(domain_path, encoding="utf-8") as f:
+                source = f.read()
+            m = re.search(r'\(:requirements\s+(.*?)\)', source, re.DOTALL)
+            requirements = m.group(1).split() if m else list(parsed_domain.requirements)
+        except OSError:
+            requirements = list(parsed_domain.requirements)
+
         return DomainInfo(
             name=parsed_domain.name,
-            requirements=list(parsed_domain.requirements),
+            requirements=requirements,
             types=types_info,
             predicates=predicates_info,
             actions=actions_info,

--- a/plugins/pddl-parser/server/backend_up.py
+++ b/plugins/pddl-parser/server/backend_up.py
@@ -446,7 +446,13 @@ class UnifiedPlanningBackend:
         truncated = False
         grounding_cap_hit = False
 
-        for action in up_problem.actions:
+        # Enumerate schemas and per-parameter objects in name-sorted order so
+        # itertools.product yields grounded actions in lex order over the
+        # output string. Combined with the early-exit at max_results, this
+        # delivers the lex-smallest N applicable actions deterministically —
+        # and identically to the pddl-plus backend (cross-backend reproducibility).
+        sorted_actions = sorted(up_problem.actions, key=lambda a: a.name)
+        for action in sorted_actions:
             if len(applicable) >= max_results:
                 truncated = True
                 break
@@ -465,13 +471,15 @@ class UnifiedPlanningBackend:
                     print(f"Warning: grounding {action.name}() failed: {e}", file=sys.stderr)
                 continue
 
-            # Build object lists per parameter type
+            # Build object lists per parameter type — sorted by object name
+            # so itertools.product yields combos in lex order.
             obj_lists = []
             for param in params:
-                matching = [
-                    obj for obj in up_problem.all_objects
-                    if self._type_matches(obj.type, param.type)
-                ]
+                matching = sorted(
+                    (obj for obj in up_problem.all_objects
+                     if self._type_matches(obj.type, param.type)),
+                    key=lambda o: o.name,
+                )
                 obj_lists.append(matching)
 
             if not all(obj_lists):
@@ -522,13 +530,14 @@ class UnifiedPlanningBackend:
 
     @staticmethod
     def _extract_requirements_from_pddl(domain_path: str) -> Optional[list[str]]:
-        """Extract requirements from PDDL domain file via regex, preserving source order."""
+        """Extract requirements from PDDL domain file via regex, preserving source order.
+        Strips ;-to-EOL comments inside the block so comments don't appear as tokens."""
         with open(domain_path) as f:
             content = f.read()
         m = re.search(r'\(:requirements\s+(.*?)\)', content, re.DOTALL)
         if not m:
             return None
-        return m.group(1).split()
+        return re.sub(r';[^\n]*', '', m.group(1)).split()
 
     def _extract_domain_info(self, up_problem, domain_name: str = None, domain_path: str = None) -> DomainInfo:
         """Extract domain-level info from a parsed UP problem."""

--- a/plugins/pddl-parser/server/backend_up.py
+++ b/plugins/pddl-parser/server/backend_up.py
@@ -522,13 +522,13 @@ class UnifiedPlanningBackend:
 
     @staticmethod
     def _extract_requirements_from_pddl(domain_path: str) -> Optional[list[str]]:
-        """Extract requirements from PDDL domain file via regex."""
+        """Extract requirements from PDDL domain file via regex, preserving source order."""
         with open(domain_path) as f:
             content = f.read()
         m = re.search(r'\(:requirements\s+(.*?)\)', content, re.DOTALL)
         if not m:
             return None
-        return sorted(m.group(1).split())
+        return m.group(1).split()
 
     def _extract_domain_info(self, up_problem, domain_name: str = None, domain_path: str = None) -> DomainInfo:
         """Extract domain-level info from a parsed UP problem."""
@@ -631,7 +631,7 @@ class UnifiedPlanningBackend:
 
         return DomainInfo(
             name=domain_name or up_problem.name,
-            requirements=sorted(requirements),
+            requirements=list(requirements),
             types=types_info,
             predicates=predicates_info,
             actions=actions_info,

--- a/plugins/pddl-parser/server/parser_server.py
+++ b/plugins/pddl-parser/server/parser_server.py
@@ -9,7 +9,7 @@ Accepts inline PDDL content strings (starting with '(') or file paths.
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Literal, Optional, Union
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import json
@@ -18,6 +18,8 @@ import re
 import shutil
 import tempfile
 import uuid
+
+ParserName = Literal["pddl-plus-parser", "unified-planning"]
 
 mcp = FastMCP("pddl-parser")
 
@@ -115,6 +117,17 @@ def _ensure_file(content_or_path: str, name: str, req_dir: str) -> str:
     )
 
 
+def _ensure_plan_file(plan_input, name: str, req_dir: str) -> str:
+    """Materialize a plan into a file, accepting list[str], str content, or path.
+    An empty list produces an empty file (valid for goal-already-satisfied)."""
+    if isinstance(plan_input, list):
+        path = os.path.join(req_dir, name)
+        with open(path, "w") as f:
+            f.write("\n".join(plan_input))
+        return path
+    return _ensure_file(plan_input, name, req_dir)
+
+
 def _clean_plan_lines(plan_path: str) -> List[str]:
     """Read a plan file and return clean action lines."""
     with open(plan_path) as f:
@@ -152,6 +165,14 @@ def _format_state(preds: list[str], is_init: bool = False) -> str:
     """Format a predicate list as a PDDL state string."""
     tag = ":init" if is_init else ":state"
     return f"({tag} {' '.join(preds)})"
+
+
+def _strip_implicit_object_type(types: dict) -> dict:
+    """Remove the implicit `"object": None` root from a types dict — it's noise
+    in callers reconstructing PDDL declarations."""
+    if not types:
+        return types
+    return {k: v for k, v in types.items() if not (k == "object" and v is None)}
 
 
 def _extract_pddl_section(content: str, keyword: str) -> Optional[str]:
@@ -359,8 +380,8 @@ def _run_with_fallback(method_name: str, parser: Optional[str], *args, **kwargs)
 def get_trajectory(
     domain: Annotated[str, Field(description="PDDL domain content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
     problem: Annotated[str, Field(description="PDDL problem content string or absolute file path to a .pddl file.")],
-    plan: Annotated[str, Field(description="Plan content string (one action per line, e.g., '(pick-up a)\\n(stack a b)') or absolute file path.")],
-    parser: Annotated[Optional[str], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
+    plan: Annotated[Union[str, list[str]], Field(description="Plan as list of action strings, content string (one action per line), or absolute file path. An empty list = empty plan (valid when init satisfies the goal).")],
+    parser: Annotated[Optional[ParserName], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
 ) -> dict:
     """Generates a full state-action-state trajectory from a PDDL domain, problem, and plan.
 
@@ -375,7 +396,7 @@ def get_trajectory(
         try:
             domain_path = _ensure_file(domain, "domain.pddl", rd)
             problem_path = _ensure_file(problem, "problem.pddl", rd)
-            plan_path = _ensure_file(plan, "plan.solution", rd)
+            plan_path = _ensure_plan_file(plan, "plan.solution", rd)
         except FileNotFoundError as e:
             return {"error": True, "message": str(e)}
 
@@ -410,7 +431,7 @@ def get_trajectory(
 def inspect_domain(
     domain: Annotated[str, Field(description="PDDL domain content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
     problem: Annotated[Optional[str], Field(description="Optional PDDL problem content string or absolute file path. When provided, adds grounded details: objects, initial state, and goal.")] = None,
-    parser: Annotated[Optional[str], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
+    parser: Annotated[Optional[ParserName], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
 ) -> dict:
     """Returns structured information about a PDDL domain: name, requirements, types, predicates, and actions.
 
@@ -436,7 +457,7 @@ def inspect_domain(
             out = {
                 "name": result.name,
                 "requirements": result.requirements,
-                "types": result.types,
+                "types": _strip_implicit_object_type(result.types),
                 "predicates": result.predicates,
                 "actions": result.actions,
                 "parser_used": parser_used,
@@ -468,7 +489,7 @@ def inspect_domain(
 def inspect_problem(
     domain: Annotated[str, Field(description="PDDL domain content string or absolute file path.")],
     problem: Annotated[str, Field(description="PDDL problem content string or absolute file path.")],
-    parser: Annotated[Optional[str], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
+    parser: Annotated[Optional[ParserName], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
 ) -> dict:
     """Returns structured information about a PDDL problem: name, objects, initial state predicates, and goal conditions.
 
@@ -507,11 +528,19 @@ def inspect_problem(
 def check_applicable(
     domain: Annotated[str, Field(description="PDDL domain content string or absolute file path.")],
     problem: Annotated[str, Field(description="PDDL problem content string or absolute file path.")],
-    state: Annotated[str, Field(description="Either 'initial' for the initial state, or a JSON array of predicate strings (e.g., '[\"(clear a)\", \"(on a b)\"]').")],
+    state: Annotated[str, Field(description="Either 'initial' for the initial state, or a JSON array of positive predicate strings (e.g., '[\"(clear a)\", \"(on a b)\"]'). Closed-world: any predicate not listed is treated as false.")],
     action: Annotated[str, Field(description="Grounded action call (e.g., '(pick-up a)' or '(stack a b)').")],
-    parser: Annotated[Optional[str], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
+    parser: Annotated[Optional[ParserName], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
 ) -> dict:
-    """Checks whether a grounded action is applicable in a given state, reporting satisfied/unsatisfied preconditions and the effects that would be applied.
+    """Checks whether a grounded action is applicable in a given state.
+
+    State semantics: closed-world. Predicates not listed in `state` are treated as false.
+    Pass the FULL list of true predicates (don't omit hand-empty when listing robot-at);
+    omitting a precondition predicate will produce a false-negative applicability verdict.
+
+    `would_add` / `would_delete` describe the effects that WOULD be applied if the action
+    were executed. They are returned for diagnosis even when `applicable=false`, where they
+    will NOT be applied to the state.
 
     Returns:
         Success: {"applicable": bool, "satisfied_preconditions": [...], "unsatisfied_preconditions": [...], "would_add": [...], "would_delete": [...], "parser_used": str}
@@ -568,14 +597,14 @@ def diff_states(
 
 @mcp.tool(annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False})
 def normalize_pddl(
-    content: Annotated[str, Field(description="PDDL domain or problem content string.")],
+    content: Annotated[str, Field(description="PDDL domain or problem content string, OR absolute file path to a .pddl file.")],
     domain: Annotated[Optional[str], Field(description="PDDL domain content string or file path. Required for full problem parsing; without it, problem parsing is partial (no action details).")] = None,
     output_format: Annotated[str, Field(description="Output format: 'pddl' for normalized PDDL text (domain only), 'json' for structured JSON.")] = "json",
 ) -> dict:
     """Parses PDDL content into a unified structured JSON representation.
 
-    Accepts domain or problem content. Bridges both parser backends into a
-    common JSON form.
+    Accepts domain or problem content (inline string or file path). Bridges both
+    parser backends into a common JSON form.
 
     - **Domain content**: returns full domain structure (types, predicates, actions).
     - **Problem content + domain**: returns full problem structure via backend
@@ -585,10 +614,21 @@ def normalize_pddl(
       validate predicates or provide action details.
 
     Returns:
-        Success: {"valid": True, "type": "domain"|"problem", "normalized": dict|str, "warnings": [...]}
-        Error: {"valid": False, "type": str, "normalized": None, "warnings": [...]}"""
+        Success: {"valid": True, "type": "domain"|"problem", "normalized": dict|str, "errors": [], "warnings": [...]}
+        Error:   {"valid": False, "type": str, "normalized": None, "errors": [...], "warnings": [...]}"""
     with _request_dir() as rd:
-        content_stripped = content.strip()
+        # Resolve path input → load content. Inline content passes through unchanged.
+        resolved_content = content
+        stripped = content.strip()
+        if not (stripped.startswith("(") or stripped.startswith(";") or "(define " in stripped):
+            if os.path.isfile(stripped):
+                with open(stripped, encoding="utf-8") as f:
+                    resolved_content = f.read()
+            elif os.path.isfile(os.path.expanduser(stripped)):
+                with open(os.path.expanduser(stripped), encoding="utf-8") as f:
+                    resolved_content = f.read()
+
+        content_stripped = resolved_content.strip()
 
         # Detect domain vs problem
         is_domain = "(domain " in content_stripped
@@ -600,12 +640,13 @@ def normalize_pddl(
                 "valid": False,
                 "type": "unknown",
                 "normalized": None,
+                "errors": ["Cannot detect PDDL type: content must contain '(domain ...' or '(problem ...'."],
                 "warnings": ["Cannot detect PDDL type: content must contain '(domain ...' or '(problem ...'."],
             }
 
         try:
             if pddl_type == "domain":
-                domain_path = _ensure_file(content, "domain.pddl", rd)
+                domain_path = _ensure_file(resolved_content, "domain.pddl", rd)
                 result, parser_used = _run_with_fallback(
                     "inspect_domain", None, domain_path
                 )
@@ -615,7 +656,7 @@ def normalize_pddl(
                     normalized = {
                         "name": result.name,
                         "requirements": result.requirements,
-                        "types": result.types,
+                        "types": _strip_implicit_object_type(result.types),
                         "predicates": result.predicates,
                         "actions": result.actions,
                         "parser_used": parser_used,
@@ -624,6 +665,7 @@ def normalize_pddl(
                     "valid": True,
                     "type": "domain",
                     "normalized": normalized,
+                    "errors": [],
                     "warnings": [],
                 }
 
@@ -633,7 +675,7 @@ def normalize_pddl(
                 if domain is not None:
                     # Full parse with backend
                     domain_path = _ensure_file(domain, "domain.pddl", rd)
-                    problem_path = _ensure_file(content, "problem.pddl", rd)
+                    problem_path = _ensure_file(resolved_content, "problem.pddl", rd)
                     prob_result, parser_used = _run_with_fallback(
                         "inspect_problem", None, domain_path, problem_path
                     )
@@ -650,7 +692,7 @@ def normalize_pddl(
                     }
                 else:
                     # Lightweight parse without domain — extract what we can
-                    normalized = _lightweight_parse_problem(content)
+                    normalized = _lightweight_parse_problem(resolved_content)
                     normalized["num_objects"] = len(normalized["objects"])
                     normalized["num_init_facts"] = len(normalized["init"])
                     normalized["num_goal_conditions"] = len(normalized["goal"])
@@ -663,15 +705,18 @@ def normalize_pddl(
                     "valid": True,
                     "type": "problem",
                     "normalized": normalized,
+                    "errors": [],
                     "warnings": warnings,
                 }
 
         except Exception as e:
+            err = f"{type(e).__name__}: {e}"
             return {
                 "valid": False,
                 "type": pddl_type,
                 "normalized": None,
-                "warnings": [f"{type(e).__name__}: {e}"],
+                "errors": [err],
+                "warnings": [err],
             }
 
 
@@ -679,11 +724,17 @@ def normalize_pddl(
 def get_applicable_actions(
     domain: Annotated[str, Field(description="PDDL domain content string or absolute file path.")],
     problem: Annotated[str, Field(description="PDDL problem content string or absolute file path.")],
-    state: Annotated[str, Field(description="Either 'initial' for the initial state, or a JSON array of predicate strings.")] = "initial",
-    max_results: Annotated[int, Field(description="Maximum number of applicable actions to return.")] = DEFAULT_MAX_APPLICABLE_ACTIONS,
-    parser: Annotated[Optional[str], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
+    state: Annotated[str, Field(description="Either 'initial' for the initial state, or a JSON array of positive predicate strings. Closed-world: predicates not listed are treated as false.")] = "initial",
+    max_results: Annotated[int, Field(description="Maximum number of applicable actions to return. When the total exceeds this cap, results are sorted lexicographically and truncated; 'truncated' is set to true.")] = DEFAULT_MAX_APPLICABLE_ACTIONS,
+    parser: Annotated[Optional[ParserName], Field(description="Parser backend: 'pddl-plus-parser', 'unified-planning', or null for auto-select with fallback.")] = None,
 ) -> dict:
-    """Enumerates all applicable grounded actions in a given state by checking every possible grounding against the state's preconditions.
+    """Enumerates applicable grounded actions in a given state.
+
+    State semantics: closed-world. Predicates not listed in `state` are treated as false —
+    pass the FULL list of true predicates.
+
+    Ordering: results are sorted lexicographically by grounded-action string before any
+    truncation, so the returned subset is deterministic across backends and runs.
 
     Returns:
         Success: {"applicable_actions": [...], "count": int, "truncated": bool, "parser_used": str}
@@ -702,9 +753,10 @@ def get_applicable_actions(
                 domain_path, problem_path, state_preds, max_results,
             )
 
+            sorted_actions = sorted(result.actions)
             out = {
-                "applicable_actions": result.actions,
-                "count": len(result.actions),
+                "applicable_actions": sorted_actions,
+                "count": len(sorted_actions),
                 "truncated": result.truncated,
                 "parser_used": parser_used,
             }

--- a/plugins/pddl-parser/server/parser_server.py
+++ b/plugins/pddl-parser/server/parser_server.py
@@ -599,7 +599,7 @@ def diff_states(
 def normalize_pddl(
     content: Annotated[str, Field(description="PDDL domain or problem content string, OR absolute file path to a .pddl file.")],
     domain: Annotated[Optional[str], Field(description="PDDL domain content string or file path. Required for full problem parsing; without it, problem parsing is partial (no action details).")] = None,
-    output_format: Annotated[str, Field(description="Output format: 'pddl' for normalized PDDL text (domain only), 'json' for structured JSON.")] = "json",
+    output_format: Annotated[Literal["pddl", "json"], Field(description="Output format: 'pddl' for normalized PDDL text (domain only), 'json' for structured JSON.")] = "json",
 ) -> dict:
     """Parses PDDL content into a unified structured JSON representation.
 

--- a/plugins/pddl-parser/server/parser_server.py
+++ b/plugins/pddl-parser/server/parser_server.py
@@ -618,13 +618,21 @@ def normalize_pddl(
         Error:   {"valid": False, "type": str, "normalized": None, "errors": [...], "warnings": [...]}"""
     with _request_dir() as rd:
         # Resolve path input → load content. Inline content passes through unchanged.
+        # Guard against OSError (e.g., ENAMETOOLONG) when a long non-PDDL string
+        # slips past the inline-content sniff and reaches isfile.
+        def _safe_isfile(p: str) -> bool:
+            try:
+                return os.path.isfile(p)
+            except OSError:
+                return False
+
         resolved_content = content
         stripped = content.strip()
         if not (stripped.startswith("(") or stripped.startswith(";") or "(define " in stripped):
-            if os.path.isfile(stripped):
+            if _safe_isfile(stripped):
                 with open(stripped, encoding="utf-8") as f:
                     resolved_content = f.read()
-            elif os.path.isfile(os.path.expanduser(stripped)):
+            elif _safe_isfile(os.path.expanduser(stripped)):
                 with open(os.path.expanduser(stripped), encoding="utf-8") as f:
                     resolved_content = f.read()
 

--- a/plugins/pddl-parser/tests/verify.py
+++ b/plugins/pddl-parser/tests/verify.py
@@ -489,6 +489,61 @@ def run_test_body() -> int:
         assert rc.returncode == 0, f"env-override subprocess failed: {rc.stderr.strip()}"
     test("env-var overrides", test_env_overrides)
 
+    # ---- Audit-fix regression tests ----
+
+    def test_normalize_pddl_accepts_path():
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".pddl", delete=False) as f:
+            f.write(DOMAIN)
+            path = f.name
+        try:
+            r = normalize_pddl(path)
+            assert r["valid"] is True, f"path input rejected: {r}"
+            assert r["type"] == "domain"
+            assert r["normalized"]["name"] == "bw"
+        finally:
+            os.unlink(path)
+    test("normalize_pddl: accepts file path", test_normalize_pddl_accepts_path)
+
+    def test_normalize_pddl_errors_field():
+        r = normalize_pddl("this is not pddl")
+        assert r["valid"] is False
+        assert "errors" in r, f"missing 'errors' field: {r}"
+        assert isinstance(r["errors"], list) and len(r["errors"]) > 0, \
+            f"errors must be non-empty list on parse failure: {r}"
+        # warnings is kept populated for backward compatibility
+        assert "warnings" in r, "warnings field must still be present for back-compat"
+    test("normalize_pddl: errors field on parse failure", test_normalize_pddl_errors_field)
+
+    def test_get_applicable_actions_sorted():
+        r = get_applicable_actions(DOMAIN, PROBLEM, "initial")
+        assert "error" not in r, r
+        actions = r["applicable_actions"]
+        assert actions == sorted(actions), \
+            f"applicable_actions must be lex-sorted for deterministic truncation: {actions}"
+    test("get_applicable_actions: lex-sorted output", test_get_applicable_actions_sorted)
+
+    # Issue 3 from the code review: confirm pddl-plus-parser's
+    # parsed_domain.requirements iteration preserves source order.
+    # If this fails, switch backend_pddl_plus.inspect_domain to regex-extract
+    # from the source file (same approach as backend_up).
+    REORDERED_DOMAIN = """(define (domain reorder-probe)
+      (:requirements :strips :typing :negative-preconditions)
+      (:types thing)
+      (:predicates (foo ?x - thing) (bar ?x - thing))
+      (:action flip :parameters (?x - thing)
+        :precondition (and (foo ?x) (not (bar ?x)))
+        :effect (and (bar ?x) (not (foo ?x)))))"""
+
+    def test_requirements_preserves_source_order():
+        for backend in BACKENDS_TO_TEST:
+            r = inspect_domain(REORDERED_DOMAIN, parser=backend)
+            assert "error" not in r, f"{backend}: {r}"
+            reqs = r["requirements"]
+            assert reqs == [":strips", ":typing", ":negative-preconditions"], \
+                f"{backend}: requirements not in source order: {reqs}"
+    test("inspect_domain: :requirements preserves source order", test_requirements_preserves_source_order)
+
     print(f"\n{passed + failed + skipped} tests: {passed} passed, {failed} failed, {skipped} skipped")
     if failed:
         print(f"\n{RED}{failed} test(s) failed.{NC}")

--- a/plugins/pddl-parser/tests/verify.py
+++ b/plugins/pddl-parser/tests/verify.py
@@ -523,6 +523,28 @@ def run_test_body() -> int:
             f"applicable_actions must be lex-sorted for deterministic truncation: {actions}"
     test("get_applicable_actions: lex-sorted output", test_get_applicable_actions_sorted)
 
+    # Cross-backend determinism: with both backends sorting schemas + object
+    # lists before enumeration, the lex-smallest N applicable actions are
+    # identical. Pins the claim in CHANGELOG / docstring / breaking-changes.
+    def test_get_applicable_actions_cross_backend_identical():
+        if not UP_AVAILABLE:
+            return
+        # Full enumeration: both backends should return the same set in the same order.
+        pp = get_applicable_actions(DOMAIN, PROBLEM, "initial", parser="pddl-plus-parser")
+        up = get_applicable_actions(DOMAIN, PROBLEM, "initial", parser="unified-planning")
+        assert "error" not in pp, pp
+        assert "error" not in up, up
+        assert pp["applicable_actions"] == up["applicable_actions"], \
+            f"backends disagree on applicable actions:\n  pp: {pp['applicable_actions']}\n  up: {up['applicable_actions']}"
+        # Truncated: the *same* lex-smallest prefix must come back from both backends.
+        pp_t = get_applicable_actions(DOMAIN, PROBLEM, "initial", max_results=2, parser="pddl-plus-parser")
+        up_t = get_applicable_actions(DOMAIN, PROBLEM, "initial", max_results=2, parser="unified-planning")
+        assert pp_t["applicable_actions"] == up_t["applicable_actions"], \
+            f"backends disagree on truncated subset:\n  pp: {pp_t['applicable_actions']}\n  up: {up_t['applicable_actions']}"
+        assert pp_t["applicable_actions"] == pp["applicable_actions"][:2], \
+            f"truncated subset is not the lex-smallest prefix: {pp_t['applicable_actions']} vs {pp['applicable_actions'][:2]}"
+    test("get_applicable_actions: cross-backend determinism", test_get_applicable_actions_cross_backend_identical)
+
     # Issue 3 from the code review: confirm pddl-plus-parser's
     # parsed_domain.requirements iteration preserves source order.
     # If this fails, switch backend_pddl_plus.inspect_domain to regex-extract

--- a/plugins/pddl-solver/CHANGELOG.md
+++ b/plugins/pddl-solver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.0
+
+- **Bug fix (behavior change):** `classic_planner` / `numeric_planner` now correctly surface environment / planner-engine failures as `{"error": True, "message": ...}`. Previously, `PlanGenerationResultStatus.INTERNAL_ERROR`, `UNSUPPORTED_PROBLEM`, and `INTERMEDIATE` were lumped into a "no plan found" response with the misleading note `"Planner ran but did not find a plan."` — callers checking `if not result["plan"]` mis-diagnosed Java-missing/missing-engine errors as unsolvable problems. ENHSP without Java now returns a clear `"Java runtime not found"` message. Statuses still routed as no-plan-found: only `UNSOLVABLE_PROVEN` / `UNSOLVABLE_INCOMPLETELY` (which legitimately mean "planner concluded no plan exists").
+- `save_plan.plan` is now typed `list[str]` (was bare `list` with untyped items). Schema-level only — no runtime change.
+- `save_plan` docstring corrected to match actual filename behavior: `name` becomes the `<tag>` inside the `plan_<tag>.solution` pattern (not a true override); collisions are suffixed with `_N`. Defaults to `~/plans/`, auto-created. See `docs/breaking-changes.md` for the audit context that motivated this clarification.
+
 ## 2.1.0
 
 - Pin the solver's CWD to its per-request temp dir during planner invocation. Fast Downward and ENHSP write intermediate files (`output.sas`, etc.) to CWD; previously this crashed in sandboxed environments with a read-only CWD (e.g., Antigravity) and silently polluted CWD elsewhere.

--- a/plugins/pddl-solver/server/solver_server.py
+++ b/plugins/pddl-solver/server/solver_server.py
@@ -175,8 +175,10 @@ def _solve(engine_name: str, domain: str, problem: str,
         # INTERNAL_ERROR / UNSUPPORTED_PROBLEM / INTERMEDIATE — the planner did
         # NOT successfully run-and-conclude-no-plan. Treat as environment error,
         # not as "no plan found" (which would lie via empty plan + misleading note).
+        # Match only the specific macOS Java-missing stub message; other env failures
+        # fall through to the generic message with the full log attached.
         trimmed_log = log[-MAX_FAILURE_LOG_CHARS:] if log else ""
-        if "Unable to locate a Java Runtime" in log or "java" in log.lower() and "not found" in log.lower():
+        if "Unable to locate a Java Runtime" in log:
             message = "Java runtime not found — required by ENHSP. Install OpenJDK 17+."
         else:
             message = f"Planner failed with status {status}"

--- a/plugins/pddl-solver/server/solver_server.py
+++ b/plugins/pddl-solver/server/solver_server.py
@@ -172,13 +172,20 @@ def _solve(engine_name: str, domain: str, problem: str,
             return {"error": True,
                     "message": "Planner ran out of memory"}
 
-        # Planner finished but no plan found
+        # INTERNAL_ERROR / UNSUPPORTED_PROBLEM / INTERMEDIATE — the planner did
+        # NOT successfully run-and-conclude-no-plan. Treat as environment error,
+        # not as "no plan found" (which would lie via empty plan + misleading note).
+        trimmed_log = log[-MAX_FAILURE_LOG_CHARS:] if log else ""
+        if "Unable to locate a Java Runtime" in log or "java" in log.lower() and "not found" in log.lower():
+            message = "Java runtime not found — required by ENHSP. Install OpenJDK 17+."
+        else:
+            message = f"Planner failed with status {status}"
         return {
-            "plan": [],
-            "solve_time": solve_time,
+            "error": True,
+            "message": message,
             "status": str(status),
-            "log": log[-MAX_FAILURE_LOG_CHARS:] if log else "",
-            "note": "Planner ran but did not find a plan.",
+            "solve_time": solve_time,
+            "log": trimmed_log,
         }
 
 
@@ -194,8 +201,10 @@ def classic_planner(
 ) -> dict:
     """Computes a plan for a classical PDDL planning problem using Fast Downward.
     Does NOT support numeric fluents or durative actions — use numeric_planner for those.
-    Returns dict with 'plan' (action list, empty if unsolvable) and 'solve_time' (seconds).
-    On failure returns dict with 'error' and 'message'."""
+    Returns:
+        Solved:      {"plan": [...], "solve_time": float}
+        Unsolvable:  {"plan": [], "solve_time": float, "note": "Problem is unsolvable"}
+        Error:       {"error": True, "message": str, ...}  (timeout, memout, internal/env failure)"""
     if strategy not in FD_STRATEGIES:
         return {
             "error": True,
@@ -217,22 +226,27 @@ def numeric_planner(
 ) -> dict:
     """Computes a plan for a PDDL problem with numeric fluents (:functions, increase, decrease) using ENHSP.
     Use this instead of classic_planner when the domain uses :functions or numeric effects.
-    Does NOT support durative/temporal actions.
-    Returns dict with 'plan' (action list, empty if unsolvable) and 'solve_time' (seconds).
-    On failure returns dict with 'error' and 'message'."""
+    Does NOT support durative/temporal actions. Requires Java 17+ at runtime.
+    Returns:
+        Solved:      {"plan": [...], "solve_time": float}
+        Unsolvable:  {"plan": [], "solve_time": float, "note": "Problem is unsolvable"}
+        Error:       {"error": True, "message": str, ...}  (timeout, memout, missing Java, internal failure)"""
     return _solve(engine_name="enhsp", domain=domain, problem=problem)
 
 
 @mcp.tool(annotations={"readOnlyHint": False, "idempotentHint": False, "openWorldHint": False})
 def save_plan(
-    plan: Annotated[list, Field(description="List of action strings to save.")],
+    plan: Annotated[list[str], Field(description="List of action strings to save.")],
     domain: Annotated[str, Field(description="Domain path or content (used to derive filename and metadata).")] = None,
     problem: Annotated[str, Field(description="Problem path or content (used to derive filename and metadata).")] = None,
-    name: Annotated[str, Field(description="Name for the plan file. Overrides domain/problem-based naming.")] = None,
-    output_dir: Annotated[str, Field(description="Directory to save the plan in. Defaults to ~/plans/.")] = None,
+    name: Annotated[str, Field(description="Name fragment for the plan file; becomes <tag> in the auto-generated `plan_<tag>.solution` pattern. Replaces (not augments) the domain/problem-derived tag.")] = None,
+    output_dir: Annotated[str, Field(description="Directory to save the plan in. Defaults to ~/plans/ (auto-created).")] = None,
     solve_time: Annotated[float, Field(description="Solve time in seconds (included in file metadata header).")] = None,
 ) -> dict:
     """Saves a computed plan to a file with metadata header.
+    Filename pattern is always `plan_<tag>.solution`, where <tag> is `name` if supplied,
+    else derived from domain/problem basenames, else a random hex. On collision, a numeric
+    suffix is appended (`plan_<tag>_1.solution`, `_2.solution`, ...).
     Returns dict with 'file_path' (path where plan was saved) and 'plan_length' (number of actions)."""
     # Tag derivation
     if name:

--- a/plugins/pddl-solver/server/solver_server.py
+++ b/plugins/pddl-solver/server/solver_server.py
@@ -6,7 +6,7 @@ Accepts inline PDDL content strings (starting with '(') or file paths.
 """
 
 from contextlib import contextmanager
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Optional
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import os
@@ -244,11 +244,11 @@ def numeric_planner(
 @mcp.tool(annotations={"readOnlyHint": False, "idempotentHint": False, "openWorldHint": False})
 def save_plan(
     plan: Annotated[list[str], Field(description="List of action strings to save.")],
-    domain: Annotated[str, Field(description="Domain path or content (used to derive filename and metadata).")] = None,
-    problem: Annotated[str, Field(description="Problem path or content (used to derive filename and metadata).")] = None,
-    name: Annotated[str, Field(description="Name fragment for the plan file; becomes <tag> in the auto-generated `plan_<tag>.solution` pattern. Replaces (not augments) the domain/problem-derived tag.")] = None,
-    output_dir: Annotated[str, Field(description="Directory to save the plan in. Defaults to ~/plans/ (auto-created).")] = None,
-    solve_time: Annotated[float, Field(description="Solve time in seconds (included in file metadata header).")] = None,
+    domain: Annotated[Optional[str], Field(description="Domain path or content (used to derive filename and metadata).")] = None,
+    problem: Annotated[Optional[str], Field(description="Problem path or content (used to derive filename and metadata).")] = None,
+    name: Annotated[Optional[str], Field(description="Name fragment for the plan file; becomes <tag> in the auto-generated `plan_<tag>.solution` pattern. Replaces (not augments) the domain/problem-derived tag.")] = None,
+    output_dir: Annotated[Optional[str], Field(description="Directory to save the plan in. Defaults to ~/plans/ (auto-created).")] = None,
+    solve_time: Annotated[Optional[float], Field(description="Solve time in seconds (included in file metadata header).")] = None,
 ) -> dict:
     """Saves a computed plan to a file with metadata header.
     Filename pattern is always `plan_<tag>.solution`, where <tag> is `name` if supplied,

--- a/plugins/pddl-solver/server/solver_server.py
+++ b/plugins/pddl-solver/server/solver_server.py
@@ -175,8 +175,13 @@ def _solve(engine_name: str, domain: str, problem: str,
         # INTERNAL_ERROR / UNSUPPORTED_PROBLEM / INTERMEDIATE — the planner did
         # NOT successfully run-and-conclude-no-plan. Treat as environment error,
         # not as "no plan found" (which would lie via empty plan + misleading note).
-        # Match only the specific macOS Java-missing stub message; other env failures
-        # fall through to the generic message with the full log attached.
+        #
+        # macOS ships a no-op `java` stub binary that prints exactly the string
+        # below when no real JRE is installed — match it for a clean user-facing
+        # message. Linux/Windows JVM-missing errors produce different text
+        # (e.g., "java: command not found") and fall through to the generic
+        # "Planner failed with status X" with the full log attached — still
+        # actionable, just not auto-classified.
         trimmed_log = log[-MAX_FAILURE_LOG_CHARS:] if log else ""
         if "Unable to locate a Java Runtime" in log:
             message = "Java runtime not found — required by ENHSP. Install OpenJDK 17+."

--- a/plugins/pddl-solver/tests/verify.py
+++ b/plugins/pddl-solver/tests/verify.py
@@ -112,12 +112,40 @@ def run_test_body() -> int:
             assert len(result["plan"]) > 0, f"Strategy {strategy}: empty plan"
     test("classic_planner (all strategies)", test_classic_strategies)
 
-    def test_numeric():
-        result = numeric_planner(NUMERIC_DOMAIN, NUMERIC_PROBLEM)
-        assert "error" not in result, f"Error: {result.get('message', result)}"
-        assert len(result["plan"]) > 0, "Expected non-empty plan"
-        assert result["solve_time"] >= 0
-    test("numeric_planner (counter)", test_numeric)
+    # macOS ships a stub `java` binary that prints "Unable to locate a Java
+    # Runtime" — so `shutil.which("java")` is unreliable. Actually invoke it.
+    def _java_actually_works() -> bool:
+        java_bin = shutil.which("java")
+        if not java_bin:
+            return False
+        try:
+            rc = subprocess.run(
+                [java_bin, "-version"], capture_output=True, timeout=5,
+            )
+            return rc.returncode == 0
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+
+    java_available = _java_actually_works()
+    if java_available:
+        def test_numeric():
+            result = numeric_planner(NUMERIC_DOMAIN, NUMERIC_PROBLEM)
+            assert "error" not in result, f"Error: {result.get('message', result)}"
+            assert len(result["plan"]) > 0, "Expected non-empty plan"
+            assert result["solve_time"] >= 0
+        test("numeric_planner (counter)", test_numeric)
+    else:
+        # Audit-fix regression: Java-missing must surface as a real error
+        # ({error: True, message: ...}), not as an empty plan with a
+        # misleading "Planner ran but did not find a plan." note.
+        def test_numeric_planner_java_missing_is_error():
+            result = numeric_planner(NUMERIC_DOMAIN, NUMERIC_PROBLEM)
+            assert result.get("error") is True, \
+                f"Java-missing must surface as error, not empty plan: {result}"
+            assert "Java" in result.get("message", ""), \
+                f"error message should mention Java: {result.get('message')!r}"
+        test("numeric_planner (Java missing → error, not no-plan)",
+             test_numeric_planner_java_missing_is_error)
 
     def test_save():
         tmp = tempfile.mkdtemp()

--- a/plugins/pddl-validator/CHANGELOG.md
+++ b/plugins/pddl-validator/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 2.2.0
+## 2.2.1
 
-- **Bug fix (behavior change):** `validate_pddl_syntax` no longer leaks the misleading `"Plan is VALID"` / `"Plan is INVALID"` line in the `report` field when no plan was executed (domain-only or domain+problem calls). pyvalidator's report formatter prints these unconditionally whenever `is_valid=True`; the plugin now strips them from the report when only syntax/consistency was checked. The `valid` boolean is unaffected.
+- **Bug fix (behavior change), now upstream:** `validate_pddl_syntax` no longer leaks the misleading `"Plan is VALID"` / `"Plan is INVALID"` line in the `report` field when no plan was executed (domain-only or domain+problem calls). The fix lives upstream in pyvalidator 0.1.5 (`SPL-BGU/pyvalidator#1`): the report formatter's "Goal Check" block is now gated on `"execution" in result.phases`, so the misleading verdict line is only emitted on actual plan-execution paths. Requirements pin bumped to `pddl-pyvalidator>=0.1.5`. The plugin-side `_strip_plan_verdict_lines` workaround introduced during PR #50 review is removed — never shipped on `main`.
 - **Edge case preserved:** an empty plan (`plan=[]` or empty file) is still validated through the full plan-execution path — correct when the initial state already satisfies the goal, in which case `"Plan is VALID"` is legitimately retained.
 - `validate_pddl_syntax.plan` and `get_state_transition.plan` now accept `list[str]` in addition to the existing `str` (content or path) form. The list is materialized as a newline-joined file internally. Existing callers passing strings are unaffected.
 - Docstring rewrite for `validate_pddl_syntax` clarifies the three modes (syntax / consistency / plan execution) so the tool's broader scope matches its name.

--- a/plugins/pddl-validator/CHANGELOG.md
+++ b/plugins/pddl-validator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.0
+
+- **Bug fix (behavior change):** `validate_pddl_syntax` no longer leaks the misleading `"Plan is VALID"` / `"Plan is INVALID"` line in the `report` field when no plan was executed (domain-only or domain+problem calls). pyvalidator's report formatter prints these unconditionally whenever `is_valid=True`; the plugin now strips them from the report when only syntax/consistency was checked. The `valid` boolean is unaffected.
+- **Edge case preserved:** an empty plan (`plan=[]` or empty file) is still validated through the full plan-execution path — correct when the initial state already satisfies the goal, in which case `"Plan is VALID"` is legitimately retained.
+- `validate_pddl_syntax.plan` and `get_state_transition.plan` now accept `list[str]` in addition to the existing `str` (content or path) form. The list is materialized as a newline-joined file internally. Existing callers passing strings are unaffected.
+- Docstring rewrite for `validate_pddl_syntax` clarifies the three modes (syntax / consistency / plan execution) so the tool's broader scope matches its name.
+
 ## 2.1.1
 
 - Bump `pddl-pyvalidator` to `>=0.1.4` to pick up the numeric-goal evaluation fix. Prior versions reported plans as `INVALID` whenever the goal contained a numeric comparison (`<=`, `>=`, `=`), affecting domains like `counters` and `farmland`. Boolean-goal domains were unaffected. No plugin API changes.

--- a/plugins/pddl-validator/requirements.txt
+++ b/plugins/pddl-validator/requirements.txt
@@ -1,3 +1,3 @@
 mcp
 pydantic
-pddl-pyvalidator>=0.1.4
+pddl-pyvalidator>=0.1.5

--- a/plugins/pddl-validator/server/validator_server.py
+++ b/plugins/pddl-validator/server/validator_server.py
@@ -6,7 +6,7 @@ Accepts inline PDDL content strings (starting with '(') or file paths.
 """
 
 from contextlib import contextmanager
-from typing import Annotated
+from typing import Annotated, Union
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import os
@@ -65,6 +65,31 @@ def _ensure_file(content_or_path: str, name: str, req_dir: str) -> str:
     )
 
 
+def _ensure_plan_file(plan_input, name: str, req_dir: str) -> str:
+    """Materialize a plan into a file, accepting list[str], str content, or path.
+    A list is written verbatim (empty list → empty file, valid when init already
+    satisfies the goal)."""
+    if isinstance(plan_input, list):
+        path = os.path.join(req_dir, name)
+        with open(path, "w") as f:
+            f.write("\n".join(plan_input))
+        return path
+    return _ensure_file(plan_input, name, req_dir)
+
+
+_PLAN_VERDICT_LINE_MARKERS = ("Plan is VALID", "Plan is INVALID")
+
+
+def _strip_plan_verdict_lines(report: str) -> str:
+    """Remove pyvalidator's 'Plan is VALID/INVALID' template lines from a report
+    when no plan was actually executed (domain-only or domain+problem syntax checks).
+    pyvalidator's formatter unconditionally appends these on `is_valid=True`."""
+    return "\n".join(
+        line for line in report.split("\n")
+        if not any(marker in line for marker in _PLAN_VERDICT_LINE_MARKERS)
+    )
+
+
 # ---------------------------------------------------------------------------
 # MCP Tools
 # ---------------------------------------------------------------------------
@@ -73,12 +98,14 @@ def _ensure_file(content_or_path: str, name: str, req_dir: str) -> str:
 def validate_pddl_syntax(
     domain: Annotated[str, Field(description="PDDL content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
     problem: Annotated[str, Field(description="PDDL content string or absolute file path to a .pddl file for the problem.")] = None,
-    plan: Annotated[str, Field(description="Plan content string or absolute file path for the action sequence to validate.")] = None,
+    plan: Annotated[Union[str, list[str], None], Field(description="Plan as list of action strings, content string, or absolute file path. An empty list is valid input — it represents the empty plan, which is correct when the initial state already satisfies the goal.")] = None,
     verbose: Annotated[bool, Field(description="When True (default), returns the full pyvalidator 'details' dict alongside the summary. Set False to drop 'details' for size-sensitive callers.")] = True,
 ) -> dict:
-    """Validates PDDL domains, problems, and plans using pyvalidator.
-    Checks syntax when given domain only, checks problem consistency when given domain+problem,
-    and verifies plan correctness when given domain+problem+plan.
+    """Validates PDDL artifacts via pyvalidator. Mode depends on arguments supplied:
+      - domain only        → syntax check of the domain.
+      - domain + problem   → syntax + domain/problem consistency check (no plan executed).
+      - domain + problem + plan → full plan-execution validation (empty plan is valid
+                                  when the initial state already satisfies the goal).
     Returns:
         verbose=True:  {"valid": bool, "status": str, "report": str, "details": dict}
         verbose=False: {"valid": bool, "status": str, "report": str}
@@ -87,23 +114,31 @@ def validate_pddl_syntax(
         try:
             dp = _ensure_file(domain, "domain.pddl", rd)
             pp = _ensure_file(problem, "problem.pddl", rd) if problem else None
-            plp = _ensure_file(plan, "plan.solution", rd) if plan else None
+            plp = _ensure_plan_file(plan, "plan.solution", rd) if plan is not None else None
         except FileNotFoundError as e:
             return {"error": True, "message": str(e)}
 
         try:
             validator = PDDLValidator()
-            if plp and pp:
+            plan_executed = plp is not None and pp is not None
+            if plan_executed:
                 result = validator.validate(dp, pp, plp)
             else:
                 result = validator.validate_syntax(dp, pp)
         except Exception as e:
             return {"error": True, "message": f"Validation error: {e}"}
 
+        report_text = result.report()
+        if not plan_executed:
+            # pyvalidator's formatter leaks "Plan is VALID" whenever is_valid=True,
+            # regardless of whether a plan was actually executed. Strip the
+            # misleading line when only syntax/consistency was checked.
+            report_text = _strip_plan_verdict_lines(report_text)
+
         out = {
             "valid": result.is_valid,
             "status": result.status,
-            "report": result.report(),
+            "report": report_text,
         }
         if verbose:
             out["details"] = result.to_json()
@@ -114,7 +149,7 @@ def validate_pddl_syntax(
 def get_state_transition(
     domain: Annotated[str, Field(description="PDDL content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
     problem: Annotated[str, Field(description="PDDL content string or absolute file path to a .pddl file for the problem definition.")],
-    plan: Annotated[str, Field(description="Plan content string or absolute file path for the solution to simulate.")],
+    plan: Annotated[Union[str, list[str]], Field(description="Plan as list of action strings, content string, or absolute file path. An empty list simulates the empty plan (initial state = final state).")],
     verbose: Annotated[bool, Field(description="When True (default), returns the verbose pyvalidator 'report' and 'details' fields alongside the structured steps/trajectory. Set False to drop both for size-sensitive callers.")] = True,
 ) -> dict:
     """Simulates plan execution step-by-step and returns the state after each action.
@@ -127,7 +162,7 @@ def get_state_transition(
         try:
             dp = _ensure_file(domain, "domain.pddl", rd)
             pp = _ensure_file(problem, "problem.pddl", rd)
-            plp = _ensure_file(plan, "plan.solution", rd)
+            plp = _ensure_plan_file(plan, "plan.solution", rd)
         except FileNotFoundError as e:
             return {"error": True, "message": str(e)}
 

--- a/plugins/pddl-validator/server/validator_server.py
+++ b/plugins/pddl-validator/server/validator_server.py
@@ -6,7 +6,7 @@ Accepts inline PDDL content strings (starting with '(') or file paths.
 """
 
 from contextlib import contextmanager
-from typing import Annotated, Union
+from typing import Annotated, Optional, Union
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import os
@@ -84,7 +84,7 @@ def _ensure_plan_file(plan_input, name: str, req_dir: str) -> str:
 @mcp.tool(annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False})
 def validate_pddl_syntax(
     domain: Annotated[str, Field(description="PDDL content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
-    problem: Annotated[str, Field(description="PDDL content string or absolute file path to a .pddl file for the problem.")] = None,
+    problem: Annotated[Optional[str], Field(description="PDDL content string or absolute file path to a .pddl file for the problem.")] = None,
     plan: Annotated[Union[str, list[str], None], Field(description="Plan as list of action strings, content string, or absolute file path. An empty list is valid input — it represents the empty plan, which is correct when the initial state already satisfies the goal.")] = None,
     verbose: Annotated[bool, Field(description="When True (default), returns the full pyvalidator 'details' dict alongside the summary. Set False to drop 'details' for size-sensitive callers.")] = True,
 ) -> dict:

--- a/plugins/pddl-validator/server/validator_server.py
+++ b/plugins/pddl-validator/server/validator_server.py
@@ -77,19 +77,6 @@ def _ensure_plan_file(plan_input, name: str, req_dir: str) -> str:
     return _ensure_file(plan_input, name, req_dir)
 
 
-_PLAN_VERDICT_LINE_MARKERS = ("Plan is VALID", "Plan is INVALID")
-
-
-def _strip_plan_verdict_lines(report: str) -> str:
-    """Remove pyvalidator's 'Plan is VALID/INVALID' template lines from a report
-    when no plan was actually executed (domain-only or domain+problem syntax checks).
-    pyvalidator's formatter unconditionally appends these on `is_valid=True`."""
-    return "\n".join(
-        line for line in report.split("\n")
-        if not any(marker in line for marker in _PLAN_VERDICT_LINE_MARKERS)
-    )
-
-
 # ---------------------------------------------------------------------------
 # MCP Tools
 # ---------------------------------------------------------------------------
@@ -120,25 +107,17 @@ def validate_pddl_syntax(
 
         try:
             validator = PDDLValidator()
-            plan_executed = plp is not None and pp is not None
-            if plan_executed:
+            if plp is not None and pp is not None:
                 result = validator.validate(dp, pp, plp)
             else:
                 result = validator.validate_syntax(dp, pp)
         except Exception as e:
             return {"error": True, "message": f"Validation error: {e}"}
 
-        report_text = result.report()
-        if not plan_executed:
-            # pyvalidator's formatter leaks "Plan is VALID" whenever is_valid=True,
-            # regardless of whether a plan was actually executed. Strip the
-            # misleading line when only syntax/consistency was checked.
-            report_text = _strip_plan_verdict_lines(report_text)
-
         out = {
             "valid": result.is_valid,
             "status": result.status,
-            "report": report_text,
+            "report": result.report(),
         }
         if verbose:
             out["details"] = result.to_json()

--- a/plugins/pddl-validator/tests/verify.py
+++ b/plugins/pddl-validator/tests/verify.py
@@ -227,6 +227,62 @@ def run_test_body() -> int:
         assert "error" not in result or result.get("status") == "SYNTAX_ERROR"
     test("validate_pddl_syntax (malformed PDDL)", test_malformed_pddl)
 
+    # Regression: pyvalidator's report formatter unconditionally appended
+    # "Plan is VALID" when is_valid=True, even on validate_syntax() calls with
+    # no plan supplied. The plugin must guarantee the misleading line is absent
+    # when no plan was executed — either via the in-plugin strip (workaround,
+    # pyvalidator <0.1.5) or via the upstream fix (pyvalidator >=0.1.5).
+    def test_no_plan_verdict_leak_domain_only():
+        result = validate_pddl_syntax(DOMAIN, verbose=False)
+        assert "error" not in result, result
+        assert "Plan is VALID" not in result["report"], \
+            f"misleading 'Plan is VALID' leaked into domain-only report: {result['report']!r}"
+        assert "Plan is INVALID" not in result["report"]
+    test("validate_pddl_syntax (no plan verdict leak — domain only)", test_no_plan_verdict_leak_domain_only)
+
+    def test_no_plan_verdict_leak_domain_problem():
+        result = validate_pddl_syntax(DOMAIN, PROBLEM, verbose=False)
+        assert "error" not in result, result
+        assert "Plan is VALID" not in result["report"], \
+            f"misleading 'Plan is VALID' leaked into domain+problem report: {result['report']!r}"
+        assert "Plan is INVALID" not in result["report"]
+    test("validate_pddl_syntax (no plan verdict leak — domain+problem)", test_no_plan_verdict_leak_domain_problem)
+
+    # Edge case: empty plan IS valid when init already satisfies the goal.
+    # Must flow through validator.validate() (plan-execution mode), not
+    # validate_syntax(), so the "Plan is VALID" line is legitimately retained.
+    GOAL_MET_PROBLEM = """(define (problem already-solved) (:domain bw)
+      (:objects a b)
+      (:init (on a b) (clear a) (ontable b) (handempty))
+      (:goal (on a b)))"""
+
+    def test_empty_plan_init_satisfies_goal():
+        result = validate_pddl_syntax(DOMAIN, GOAL_MET_PROBLEM, plan=[], verbose=False)
+        assert "error" not in result, result
+        assert result["valid"] is True, f"empty plan with init satisfying goal should be VALID: {result}"
+        assert result["status"] == "VALID"
+        # Plan-execution path WAS taken (because plan=[] is a list, not None),
+        # so the "Plan is VALID" line is meaningful and should appear.
+        assert "Plan is VALID" in result["report"], \
+            f"empty plan validating a goal-already-met problem should report 'Plan is VALID': {result['report']!r}"
+    test("validate_pddl_syntax (empty plan, init satisfies goal)", test_empty_plan_init_satisfies_goal)
+
+    # list[str] plan input is the additive widening — should be equivalent to
+    # joining and passing as a content string.
+    def test_plan_as_list():
+        result = validate_pddl_syntax(DOMAIN, PROBLEM, plan=["(pick-up a)", "(stack a b)"], verbose=False)
+        assert "error" not in result, result
+        assert result["valid"] is True, f"list-form plan rejected: {result}"
+        assert result["status"] == "VALID"
+    test("validate_pddl_syntax (plan as list[str])", test_plan_as_list)
+
+    def test_state_transition_plan_as_list():
+        result = get_state_transition(DOMAIN, PROBLEM, plan=["(pick-up a)", "(stack a b)"], verbose=False)
+        assert "error" not in result, result
+        assert result["valid"] is True
+        assert len(result["steps"]) == 2
+    test("get_state_transition (plan as list[str])", test_state_transition_plan_as_list)
+
     print(f"\n{passed + failed} tests: {passed} passed, {failed} failed")
     if failed:
         print(f"\n{RED}Tests failed.{NC}")


### PR DESCRIPTION
## Summary

Consolidated PR addressing the May-2026 tool interface audit. Two headline bugs plus a batch of additive widenings and response-shape cleanups across all three MCP plugins.

Full migration log: [`docs/breaking-changes.md`](./docs/breaking-changes.md).

## Critical bug fixes

- **pddl-validator** — `validate_pddl_syntax` no longer leaks pyvalidator's `"Plan is VALID"` / `"Plan is INVALID"` line in `report` when no plan was executed (domain-only or domain+problem calls). The `valid` boolean and `status` are unchanged.
  - **Edge case preserved**: an empty plan (`plan=[]`) flows through the full plan-execution path. When the initial state already satisfies the goal, the line is legitimately retained.
- **pddl-solver** — `classic_planner` / `numeric_planner` now surface `INTERNAL_ERROR` / `UNSUPPORTED_PROBLEM` / `INTERMEDIATE` as `{"error": True, "message": ..., "status": ..., "solve_time": ..., "log": ...}`. ENHSP without Java returns a clear `"Java runtime not found"` message. Only `UNSOLVABLE_PROVEN` / `UNSOLVABLE_INCOMPLETELY` continue to route as no-plan-found.

## Additive widenings (non-breaking)

- `list[str]` plan accepted on `validate_pddl_syntax`, `get_state_transition`, `get_trajectory`.
- `normalize_pddl` accepts file paths in the `content` argument; response adds a dedicated `errors` field (kept `warnings` populated for compat).
- `parser` parameter is now `Literal["pddl-plus-parser", "unified-planning"]` across all parser tools.

## Response-shape fixes

- `inspect_domain.types` / `normalize_pddl.normalized.types` drop the implicit `"object": null` root.
- `:requirements` preserves the order declared in the PDDL source (was alphabetized).
- `get_applicable_actions` sorts results lexicographically before truncation — truncated subsets are now deterministic across backends and runs.
- `save_plan` docstring corrected to match actual filename behavior (behavior unchanged).
- `check_applicable` / `get_applicable_actions` docstrings now state closed-world semantics and the diagnostic nature of `would_add` / `would_delete`.

## Versions

| Plugin | From | To |
|---|---|---|
| pddl-solver | 2.1.1 | 2.2.0 |
| pddl-validator | 2.1.1 | 2.2.1 |
| pddl-parser | 1.4.0 | 1.5.0 |
| marketplace | 1.2.0 | 1.3.0 |

Both `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` bumped.

## Test plan

- [x] `plugins/pddl-validator/tests/verify.py` — 16/16 pass
- [x] `plugins/pddl-parser/tests/verify.py` — 39/39 pass
- [x] `plugins/pddl-solver/tests/verify.py` — 11/12 (sole failure is `numeric_planner` Java-missing on dev box; the surfaced error message is exactly what the fix introduces)
- [x] Empty-plan edge case verified (4 scenarios: domain-only / domain+problem / empty-plan-init-satisfies-goal / real valid plan)
- [x] Experiments-repo validator agent ran against `SPL-BGU/pddl-copilot-experiments` → **OVERALL: SAFE** across solver error shape, report text, list-plan widening, parser changes, and pinned `verbose=False`
- [ ] CI green
- [ ] Reviewer sanity-check on `docs/breaking-changes.md` migration log

> **Update 2026-05-19 (review pass 2):** pyvalidator 0.1.5 ([SPL-BGU/pyvalidator#1](https://github.com/SPL-BGU/pyvalidator/pull/1)) lands the upstream Goal-Check gating fix. Workaround `_strip_plan_verdict_lines` removed; `pddl-pyvalidator>=0.1.5` pinned; pddl-validator bumped to **2.2.1**. Cross-backend determinism for `get_applicable_actions` now actually delivered (sort happens during enumeration in both backends, not post-hoc).

## Deferred

Audit findings that need cross-repo coordination — explicitly listed in `docs/breaking-changes.md`:
- Unify state-serialization formats across `get_trajectory` / `get_state_transition.trajectory` / `diff_states`+`check_applicable`+`get_applicable_actions` (oracle byte-equality lock)
- Rename `validate_pddl_syntax` → `validate_pddl`
- True `save_plan.name` filename override (current behavior is a tag fragment)
- Shrink `validate_pddl_syntax.report` on `verbose=False`
- `get_applicable_actions` `hide_no_op` flag
