### PR TITLE
chore(skills): align simplify with bundled /code-review

### DIFF
--- a/.claude/agents/simplifier.md
+++ b/.claude/agents/simplifier.md
@@ -3,7 +3,7 @@ name: simplifier
 description: Reviews plans and code for unnecessary complexity, plugin isolation violations, and MCP convention issues. Use after planning or before committing multi-file changes.
 tools: Read, Grep, Glob
 model: opus
-effort: high
+effort: xhigh
 permissionMode: plan
 maxTurns: 10
 ---

--- a/.claude/agents/simplifier.md
+++ b/.claude/agents/simplifier.md
@@ -3,6 +3,7 @@ name: simplifier
 description: Reviews plans and code for unnecessary complexity, plugin isolation violations, and MCP convention issues. Use after planning or before committing multi-file changes.
 tools: Read, Grep, Glob
 model: opus
+effort: high
 permissionMode: plan
 maxTurns: 10
 ---

--- a/.claude/skills/debug-and-simplify/SKILL.md
+++ b/.claude/skills/debug-and-simplify/SKILL.md
@@ -54,6 +54,7 @@ Before committing the fix, review it:
 1. Run the plugin's `tests/verify.py` to confirm the fix
 2. If the issue was in CI/CD, trigger a manual workflow run: `gh workflow run <workflow>`
 3. Report: what broke, why, what was fixed, verification result
+4. If `tests/verify.py` is missing or doesn't fully cover the plugin's MCP tools, run bundled `/run-skill-generator` once for that plugin so bundled `/verify` can replay the launch + smoke recipe in future sessions (requires Claude Code v2.1.145+).
 
 ### Common Issues Reference
 

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -4,9 +4,13 @@ description: Review current plan or code changes for unnecessary complexity, plu
 context: fork
 agent: simplifier
 argument-hint: [description of what to review]
+paths: plugins/**
 ---
 
 Review the current work for unnecessary complexity and correctness.
+
+> **Layering with bundled `/code-review`:** As of Claude Code v2.1.147, bundled `/code-review` (formerly `/simplify`) handles general correctness at the chosen effort level (e.g. `/code-review high`). This skill adds project-specific concerns the bundled reviewer cannot know: plugin-isolation boundaries, MCP/FastMCP conventions, architecture-tier appropriateness, and scope placement (dev vs user-facing). Run both — `/code-review high` first or in parallel.
+
 
 $ARGUMENTS
 


### PR DESCRIPTION
## Summary
Claude Code v2.1.147 renamed bundled `/simplify` to `/code-review`. Our local `/simplify` is now a project-specific layer (plugin-isolation, MCP conventions, architecture-tier checks) on top of the bundled reviewer.

## Changes
- Layering note in `.claude/skills/simplify/SKILL.md` pointing at `/code-review high`.
- `paths: plugins/**` scopes auto-invocation to plugin work.
- `debug-and-simplify` now references bundled `/run-skill-generator` for per-plugin verify recipes (v2.1.145+).
- `effort: high` added to the simplifier subagent.