### PR TITLE
fix: cross-backend trajectory canonicalization, validator status, false-passing test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -43,7 +43,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "source": "./plugins/pddl-parser",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -30,7 +30,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "source": "./plugins/pddl-validator",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
@@ -44,7 +44,7 @@
         "name": "SPL-BGU"
       },
       "license": "MIT",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "source": "./plugins/pddl-parser",
       "homepage": "https://github.com/SPL-BGU/pddl-copilot",
       "repository": "https://github.com/SPL-BGU/pddl-copilot",

--- a/plugins/pddl-parser/.claude-plugin/plugin.json
+++ b/plugins/pddl-parser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-parser",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "PDDL introspection, trajectory generation, applicability checking, and state analysis. Pure Python, no Docker.",
   "author": {
     "name": "SPL-BGU"

--- a/plugins/pddl-parser/CHANGELOG.md
+++ b/plugins/pddl-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.1
+
+- **Fix:** the `unified-planning` backend now emits the `get_trajectory` `action` field in canonical s-expression form with the domain-resolved (lowercased) name *and* argument names — e.g. `(pick-up a)` — instead of echoing the raw input string. Previously UP returned the input verbatim (`pick-up(a)`, or `(pick-up A)` for mixed-case args), which diverged from the `pddl-plus-parser` backend and broke the documented "both backends produce identical canonical output" contract under auto-fallback. Since UP is the default backend for non-numeric domains, this affected the default trajectory output.
+
 ## 1.6.0
 
 - `get_trajectory` docstring adds a cross-reference distinguishing it from the validator's `get_state_transition`: this tool is for clean trajectory *extraction* on known-valid plans (dual-backend, leaner shape, no diagnostics); `get_state_transition` is for *debugging* with rich per-step precondition failures. Motivated by LLM tool-selection ambiguity between the two near-synonymous names.

--- a/plugins/pddl-parser/server/backend_up.py
+++ b/plugins/pddl-parser/server/backend_up.py
@@ -25,6 +25,7 @@ from backends import (
     ProblemInfo,
     TrajectoryResult,
     TrajectoryStep,
+    canonicalize_action,
     normalize_action_input,
     suggest_close_match,
 )
@@ -282,7 +283,7 @@ class UnifiedPlanningBackend:
 
             steps.append(TrajectoryStep(
                 state_predicates=state_preds,
-                action=action_str,
+                action=canonicalize_action(schema.name, param_names),
             ))
             state = simulator.apply(state, instance)
 

--- a/plugins/pddl-parser/server/backend_up.py
+++ b/plugins/pddl-parser/server/backend_up.py
@@ -283,7 +283,7 @@ class UnifiedPlanningBackend:
 
             steps.append(TrajectoryStep(
                 state_predicates=state_preds,
-                action=canonicalize_action(schema.name, param_names),
+                action=canonicalize_action(schema.name, [o.name for o in param_objects]),
             ))
             state = simulator.apply(state, instance)
 

--- a/plugins/pddl-parser/tests/verify.py
+++ b/plugins/pddl-parser/tests/verify.py
@@ -546,16 +546,17 @@ def run_test_body() -> int:
     test("get_applicable_actions: cross-backend determinism", test_get_applicable_actions_cross_backend_identical)
 
     # Cross-backend canonical action: both backends must emit the action field in
-    # canonical s-expression form "(name arg ...)", regardless of the input format.
-    # UP previously echoed the raw input verbatim, so "pick-up(a)" came back as
-    # "pick-up(a)" from UP but "(pick-up a)" from pddl-plus — breaking the
-    # "both backends produce identical canonical output" contract under auto-fallback.
+    # canonical s-expression form "(name arg ...)" with the domain-resolved (lowercased)
+    # name AND argument names, regardless of the input casing or format. UP previously
+    # echoed the raw input verbatim; a partial fix canonicalized only the name, leaving
+    # mixed-case args ("(pick-up A)") divergent from pddl-plus ("(pick-up a)"). Mixed-case
+    # input is the load-bearing case here — lowercase input cannot catch arg divergence.
     def test_get_trajectory_cross_backend_canonical_action():
         if not UP_AVAILABLE:
             return
-        functional_plan = ["pick-up(a)", "stack(a, b)"]
-        pp = get_trajectory(DOMAIN, PROBLEM, functional_plan, parser="pddl-plus-parser")
-        up = get_trajectory(DOMAIN, PROBLEM, functional_plan, parser="unified-planning")
+        mixed_case_plan = ["PICK-UP(A)", "Stack(A, b)"]
+        pp = get_trajectory(DOMAIN, PROBLEM, mixed_case_plan, parser="pddl-plus-parser")
+        up = get_trajectory(DOMAIN, PROBLEM, mixed_case_plan, parser="unified-planning")
         assert "error" not in pp, pp
         assert "error" not in up, up
         pp_actions = [step["action"] for step in pp["trajectory"].values()]

--- a/plugins/pddl-parser/tests/verify.py
+++ b/plugins/pddl-parser/tests/verify.py
@@ -545,6 +545,26 @@ def run_test_body() -> int:
             f"truncated subset is not the lex-smallest prefix: {pp_t['applicable_actions']} vs {pp['applicable_actions'][:2]}"
     test("get_applicable_actions: cross-backend determinism", test_get_applicable_actions_cross_backend_identical)
 
+    # Cross-backend canonical action: both backends must emit the action field in
+    # canonical s-expression form "(name arg ...)", regardless of the input format.
+    # UP previously echoed the raw input verbatim, so "pick-up(a)" came back as
+    # "pick-up(a)" from UP but "(pick-up a)" from pddl-plus — breaking the
+    # "both backends produce identical canonical output" contract under auto-fallback.
+    def test_get_trajectory_cross_backend_canonical_action():
+        if not UP_AVAILABLE:
+            return
+        functional_plan = ["pick-up(a)", "stack(a, b)"]
+        pp = get_trajectory(DOMAIN, PROBLEM, functional_plan, parser="pddl-plus-parser")
+        up = get_trajectory(DOMAIN, PROBLEM, functional_plan, parser="unified-planning")
+        assert "error" not in pp, pp
+        assert "error" not in up, up
+        pp_actions = [step["action"] for step in pp["trajectory"].values()]
+        up_actions = [step["action"] for step in up["trajectory"].values()]
+        assert pp_actions == ["(pick-up a)", "(stack a b)"], pp_actions
+        assert pp_actions == up_actions, \
+            f"backends disagree on action format:\n  pp: {pp_actions}\n  up: {up_actions}"
+    test("get_trajectory: cross-backend canonical action", test_get_trajectory_cross_backend_canonical_action)
+
     # Issue 3 from the code review: confirm pddl-plus-parser's
     # parsed_domain.requirements iteration preserves source order.
     # If this fails, switch backend_pddl_plus.inspect_domain to regex-extract

--- a/plugins/pddl-validator/.claude-plugin/plugin.json
+++ b/plugins/pddl-validator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-validator",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Validate PDDL domains, problems, and plans — check syntax, verify plan correctness, and inspect state transitions. Pure pip install, no Docker.",
   "author": {
     "name": "SPL-BGU"

--- a/plugins/pddl-validator/CHANGELOG.md
+++ b/plugins/pddl-validator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.1
+
+- **Fix:** `get_state_transition` now always includes `status` in its output (matching the `validate_*` family). Previously a `STRUCTURE_ERROR`/`SYNTAX_ERROR` (undefined action, wrong arity, malformed PDDL) returned `{"valid": false, "steps": [], "trajectory": []}` — indistinguishable from a plan that executed and failed. Callers can now read `status` to tell "never simulated" apart from "ran and failed".
+- **Fix:** `validate_plan` and `get_state_transition` no longer surface a generic `{"error": true}` server error when a numeric plan references a fluent the problem never initialized (common on farmland / zenotravel-numeric). pyvalidator's "does not have a value" exception is re-shaped into a structured `{"valid": false, "status": "PRECONDITION_ERROR", ...}` verdict. New status value: `PRECONDITION_ERROR`.
+
 ## 3.0.0 — BREAKING
 
 **Tool surface change.** `validate_pddl_syntax` is split into three task-aligned tools to eliminate the argument-shape polymorphism that was the dominant cause of plan-validation failures in downstream LLM consumers (a `(domain, problem)` call returns the consistency verdict, *not* the plan verdict — the previous name "validate_pddl_syntax" did not advertise that gotcha).

--- a/plugins/pddl-validator/server/validator_server.py
+++ b/plugins/pddl-validator/server/validator_server.py
@@ -92,6 +92,32 @@ def _syntax_result_to_dict(result, verbose: bool) -> dict:
     return out
 
 
+def _precondition_error_or_none(e: Exception, verbose: bool) -> dict | None:
+    """Detect pyvalidator's unknown-fluent precondition-lookup exception and
+    re-shape it as a structured verdict instead of a generic server error.
+
+    pyvalidator raises (instead of returning a structured verdict) when a plan
+    references a numeric fluent the problem didn't initialize — common on
+    farmland and zenotravel-numeric broken-plan fixtures. The substring match
+    against pyvalidator's English message is intentionally narrow; if the
+    upstream message changes, this returns None and the caller falls back to its
+    generic error envelope.
+
+    Returns the structured dict on a match, or None to let the caller decide.
+    """
+    msg = str(e)
+    if "does not have a value" not in msg:
+        return None
+    out = {
+        "valid": False,
+        "status": "PRECONDITION_ERROR",
+        "report": msg,
+    }
+    if verbose:
+        out["details"] = {"unknown_fluent": True, "message": msg}
+    return out
+
+
 @mcp.tool(annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False})
 def validate_domain(
     domain: Annotated[str, Field(description="PDDL content string (e.g., '(define (domain ...) ...)') or absolute file path to a .pddl file.")],
@@ -177,7 +203,9 @@ def validate_plan(
                         with get_state_transition, which drops BOTH at verbose=False.)
         Error:         {"error": True, "message": str}
 
-        status is one of: "VALID", "INVALID", "SYNTAX_ERROR", "STRUCTURE_ERROR"."""
+        status is one of: "VALID", "INVALID", "SYNTAX_ERROR", "STRUCTURE_ERROR",
+        "PRECONDITION_ERROR" (a numeric plan referenced an uninitialized fluent —
+        returned as a structured verdict instead of a server error)."""
     with _request_dir() as rd:
         try:
             dp = _ensure_file(domain, "domain.pddl", rd)
@@ -189,6 +217,9 @@ def validate_plan(
         try:
             result = PDDLValidator().validate(dp, pp, plp)
         except Exception as e:
+            precondition_result = _precondition_error_or_none(e, verbose)
+            if precondition_result is not None:
+                return precondition_result
             return {"error": True, "message": f"Validation error: {e}"}
 
         return _syntax_result_to_dict(result, verbose)
@@ -215,11 +246,15 @@ def get_state_transition(
         verbose=False: {"valid": bool, "status": str, "steps": list, "trajectory": list}
                        (drops BOTH "report" and "details". This is asymmetric with
                         validate_plan, where verbose=False keeps "report".)
+        Precondition:  {"valid": False, "status": "PRECONDITION_ERROR", "report": str, ...}
+                       (numeric plan referenced an uninitialized fluent — verbose=True
+                        adds a "details" key; steps/trajectory are not produced)
         Error:         {"error": True, "message": str}
 
-        status is one of: "VALID", "INVALID", "SYNTAX_ERROR", "STRUCTURE_ERROR". On a
-        SYNTAX_ERROR (bad domain/problem) or STRUCTURE_ERROR (undefined action, wrong
-        arity) the plan never simulates, so "steps"/"trajectory" are empty — read
+        status is one of: "VALID", "INVALID", "SYNTAX_ERROR", "STRUCTURE_ERROR",
+        "PRECONDITION_ERROR". On a SYNTAX_ERROR (bad domain/problem), STRUCTURE_ERROR
+        (undefined action, wrong arity) or PRECONDITION_ERROR (uninitialized numeric
+        fluent) the plan never simulates, so "steps"/"trajectory" are empty — read
         "status" to tell that apart from a plan that executed and failed."""
     with _request_dir() as rd:
         try:
@@ -233,6 +268,9 @@ def get_state_transition(
             validator = PDDLValidator()
             result = validator.validate(dp, pp, plp)
         except Exception as e:
+            precondition_result = _precondition_error_or_none(e, verbose)
+            if precondition_result is not None:
+                return precondition_result
             return {"error": True, "message": f"Validation error: {e}"}
 
         # Build step-by-step output

--- a/plugins/pddl-validator/server/validator_server.py
+++ b/plugins/pddl-validator/server/validator_server.py
@@ -211,11 +211,16 @@ def get_state_transition(
     An empty plan (`[]`) simulates the empty plan (initial state = final state).
 
     Returns:
-        verbose=True:  {"valid": bool, "report": str, "steps": list, "trajectory": list, "details": dict}
-        verbose=False: {"valid": bool, "steps": list, "trajectory": list}
+        verbose=True:  {"valid": bool, "status": str, "report": str, "steps": list, "trajectory": list, "details": dict}
+        verbose=False: {"valid": bool, "status": str, "steps": list, "trajectory": list}
                        (drops BOTH "report" and "details". This is asymmetric with
                         validate_plan, where verbose=False keeps "report".)
-        Error:         {"error": True, "message": str}"""
+        Error:         {"error": True, "message": str}
+
+        status is one of: "VALID", "INVALID", "SYNTAX_ERROR", "STRUCTURE_ERROR". On a
+        SYNTAX_ERROR (bad domain/problem) or STRUCTURE_ERROR (undefined action, wrong
+        arity) the plan never simulates, so "steps"/"trajectory" are empty — read
+        "status" to tell that apart from a plan that executed and failed."""
     with _request_dir() as rd:
         try:
             dp = _ensure_file(domain, "domain.pddl", rd)
@@ -271,6 +276,7 @@ def get_state_transition(
 
         out = {
             "valid": result.is_valid,
+            "status": result.status,
             "steps": steps,
             "trajectory": trajectory,
         }

--- a/plugins/pddl-validator/skills/pddl-validation/SKILL.md
+++ b/plugins/pddl-validator/skills/pddl-validation/SKILL.md
@@ -37,11 +37,11 @@ For `plan`, you can additionally pass a `list[str]` of action lines.
 
 The three `validate_*` tools return:
 - `valid` — boolean. For `validate_domain`/`validate_problem`, reflects syntax/consistency. For `validate_plan`, reflects plan correctness.
-- `status` — one of `VALID`, `INVALID`, `SYNTAX_ERROR`, `STRUCTURE_ERROR`.
+- `status` — one of `VALID`, `INVALID`, `SYNTAX_ERROR`, `STRUCTURE_ERROR`, `PRECONDITION_ERROR`. `validate_plan` and `get_state_transition` return `PRECONDITION_ERROR` (as a structured verdict, not a server error) when a numeric plan references a fluent the problem never initialized.
 - `report` — human-readable text summary.
 - `details` (verbose=True only) — full structured validation result.
 
-`get_state_transition` returns `valid` + `status` + `steps[]` + `trajectory[]` (and `report` + `details` if verbose=True). A `SYNTAX_ERROR`/`STRUCTURE_ERROR` `status` means the plan never simulated (empty `steps`/`trajectory`); a `VALID`/`INVALID` `status` means it executed. Invalid steps include per-precondition failure diagnostics with current values and deficit amounts.
+`get_state_transition` returns `valid` + `status` + `steps[]` + `trajectory[]` (and `report` + `details` if verbose=True). A `SYNTAX_ERROR`/`STRUCTURE_ERROR`/`PRECONDITION_ERROR` `status` means the plan never simulated (empty `steps`/`trajectory`); a `VALID`/`INVALID` `status` means it executed. Invalid steps include per-precondition failure diagnostics with current values and deficit amounts.
 
 ### `verbose=False` (size-sensitive callers)
 

--- a/plugins/pddl-validator/skills/pddl-validation/SKILL.md
+++ b/plugins/pddl-validator/skills/pddl-validation/SKILL.md
@@ -23,7 +23,7 @@ Do NOT tell the user the PDDL is correct based on your own analysis alone.
 - `validate_domain(domain, verbose?)` — Validates a PDDL domain's syntax, types, and structural consistency (calls pyvalidator's `validate_syntax(domain, None)`). NOT a lexical-only check — covers type-hierarchy soundness, predicate arity, and section nesting. Default `verbose=True` returns `{"valid": bool, "status": str, "report": str, "details": dict}`. With `verbose=False`, drops `details` only.
 - `validate_problem(domain, problem, verbose?)` — Validates that a PDDL problem is consistent with its domain (objects, predicates, types resolve). Does NOT validate a plan. Same return shape as `validate_domain`.
 - `validate_plan(domain, problem, plan, verbose?)` — Executes a plan against the (domain, problem) and reports whether it reaches the goal. The `valid` field reflects **plan correctness** (preconditions held + goal satisfied), not just syntax. Empty plan `[]` is valid input — represents the empty plan, correct when init already satisfies goal. Same return shape as `validate_domain` plus details on per-step failures.
-- `get_state_transition(domain, problem, plan, verbose?)` — Simulates plan execution step-by-step. Use to debug or inspect intermediate states. For a PASS/FAIL verdict, use `validate_plan` instead — it's cheaper and returns a flat shape. Default `verbose=True` returns `{"valid": bool, "report": str, "steps": list, "trajectory": list, "details": dict}`. With `verbose=False`, drops **both** `report` and `details`.
+- `get_state_transition(domain, problem, plan, verbose?)` — Simulates plan execution step-by-step. Use to debug or inspect intermediate states. For a PASS/FAIL verdict, use `validate_plan` instead — it's cheaper and returns a flat shape. Default `verbose=True` returns `{"valid": bool, "status": str, "report": str, "steps": list, "trajectory": list, "details": dict}`. With `verbose=False`, drops **both** `report` and `details` (keeps `status`).
 
 ### These tools accept PDDL content strings OR file paths
 
@@ -41,7 +41,7 @@ The three `validate_*` tools return:
 - `report` — human-readable text summary.
 - `details` (verbose=True only) — full structured validation result.
 
-`get_state_transition` returns `valid` + `steps[]` + `trajectory[]` (and `report` + `details` if verbose=True). Invalid steps include per-precondition failure diagnostics with current values and deficit amounts.
+`get_state_transition` returns `valid` + `status` + `steps[]` + `trajectory[]` (and `report` + `details` if verbose=True). A `SYNTAX_ERROR`/`STRUCTURE_ERROR` `status` means the plan never simulated (empty `steps`/`trajectory`); a `VALID`/`INVALID` `status` means it executed. Invalid steps include per-precondition failure diagnostics with current values and deficit amounts.
 
 ### `verbose=False` (size-sensitive callers)
 

--- a/plugins/pddl-validator/tests/verify.py
+++ b/plugins/pddl-validator/tests/verify.py
@@ -230,6 +230,34 @@ def run_test_body() -> int:
         assert "numeric" in step.get("changes", {}), f"Expected numeric changes: {step}"
     test("get_state_transition (numeric)", test_state_transition_numeric)
 
+    # A plan that reads a numeric fluent the problem never initialized makes
+    # pyvalidator raise; both tools must re-shape that as a structured
+    # PRECONDITION_ERROR verdict rather than bubbling up an {"error": True} server error.
+    UNINIT_FLUENT_DOMAIN = """(define (domain fuel) (:requirements :strips :typing :fluents)
+ (:types truck) (:functions (fuel ?t - truck))
+ (:action drive :parameters (?t - truck)
+   :precondition (>= (fuel ?t) 1) :effect (decrease (fuel ?t) 1)))"""
+    UNINIT_FLUENT_PROBLEM = """(define (problem p) (:domain fuel) (:objects t1 - truck)
+ (:init) (:goal (<= (fuel t1) 0)))"""
+    UNINIT_FLUENT_PLAN = ["(drive t1)"]
+
+    def test_validate_plan_uninitialized_fluent_precondition_error():
+        result = validate_plan(UNINIT_FLUENT_DOMAIN, UNINIT_FLUENT_PROBLEM, UNINIT_FLUENT_PLAN, verbose=False)
+        assert "error" not in result, f"unexpected server error: {result}"
+        assert result["valid"] is False
+        assert result["status"] == "PRECONDITION_ERROR", \
+            f"expected PRECONDITION_ERROR, got {result.get('status')}"
+    test("validate_plan (uninitialized fluent -> PRECONDITION_ERROR)", test_validate_plan_uninitialized_fluent_precondition_error)
+
+    def test_state_transition_uninitialized_fluent_precondition_error():
+        result = get_state_transition(UNINIT_FLUENT_DOMAIN, UNINIT_FLUENT_PROBLEM, UNINIT_FLUENT_PLAN, verbose=True)
+        assert "error" not in result, f"unexpected server error: {result}"
+        assert result["valid"] is False
+        assert result["status"] == "PRECONDITION_ERROR", \
+            f"expected PRECONDITION_ERROR, got {result.get('status')}"
+        assert result["details"]["unknown_fluent"] is True
+    test("get_state_transition (uninitialized fluent -> PRECONDITION_ERROR)", test_state_transition_uninitialized_fluent_precondition_error)
+
     def test_typed_hierarchy_subtype_accepted():
         result = validate_plan(TYPED_DOMAIN, TYPED_PROBLEM, TYPED_SUBTYPE_PLAN)
         assert "error" not in result, f"Error: {result.get('message', result)}"

--- a/plugins/pddl-validator/tests/verify.py
+++ b/plugins/pddl-validator/tests/verify.py
@@ -184,15 +184,26 @@ def run_test_body() -> int:
 
     def test_state_transition_verbose_default_has_report_details():
         result = get_state_transition(DOMAIN, PROBLEM, VALID_PLAN)
-        assert set(result.keys()) == {"valid", "report", "steps", "trajectory", "details"}, f"Unexpected keys: {result.keys()}"
+        assert set(result.keys()) == {"valid", "status", "report", "steps", "trajectory", "details"}, f"Unexpected keys: {result.keys()}"
     test("get_state_transition (default verbose=True)", test_state_transition_verbose_default_has_report_details)
 
     def test_state_transition_verbose_false_slim():
         result = get_state_transition(DOMAIN, PROBLEM, VALID_PLAN, verbose=False)
-        assert set(result.keys()) == {"valid", "steps", "trajectory"}, f"Unexpected keys: {result.keys()}"
+        assert set(result.keys()) == {"valid", "status", "steps", "trajectory"}, f"Unexpected keys: {result.keys()}"
         assert len(result["trajectory"]) >= 1
         assert "boolean_fluents" in result["trajectory"][0]
     test("get_state_transition (verbose=False slim, uncapped)", test_state_transition_verbose_false_slim)
+
+    def test_state_transition_structure_error_surfaces_status():
+        # Undefined action: the plan never simulates, so steps/trajectory are empty.
+        # status must still distinguish this from an executed-but-failed plan.
+        result = get_state_transition(DOMAIN, PROBLEM, plan=["(bogus-action a b)"], verbose=False)
+        assert "error" not in result, result
+        assert result["valid"] is False
+        assert result["status"] == "STRUCTURE_ERROR", \
+            f"expected STRUCTURE_ERROR for undefined action, got {result.get('status')}"
+        assert result["steps"] == [] and result["trajectory"] == []
+    test("get_state_transition (structure error surfaces status)", test_state_transition_structure_error_surfaces_status)
 
     def test_numeric_validation():
         result = validate_plan(NUMERIC_DOMAIN, NUMERIC_PROBLEM, NUMERIC_PLAN)
@@ -233,8 +244,13 @@ def run_test_body() -> int:
     test("validate_plan (typed hierarchy, sibling rejected)", test_typed_hierarchy_sibling_rejected)
 
     def test_malformed_pddl():
-        result = validate_domain("(define (domain broken))")
-        assert "error" not in result or result.get("status") == "SYNTAX_ERROR"
+        # Unbalanced parens — genuinely malformed. "(define (domain broken))" is
+        # actually a VALID empty domain, so it never exercised the rejection path.
+        result = validate_domain("(define (domain broken)")
+        assert "error" not in result, result
+        assert result["valid"] is False, f"malformed domain accepted: {result}"
+        assert result["status"] == "SYNTAX_ERROR", \
+            f"expected SYNTAX_ERROR, got {result.get('status')}"
     test("validate_domain (malformed PDDL)", test_malformed_pddl)
 
     # Regression: pyvalidator's report formatter unconditionally appended


### PR DESCRIPTION
## Summary

Fixes from the repo-wide review, plus one cherry-pick from #56.

- **pddl-parser 1.6.1 (HIGH)** — `UnifiedPlanningBackend.get_trajectory` stored the **raw input** action string, so `pick-up(a)` came back verbatim from UP but `(pick-up a)` from pddl-plus, violating the documented "both backends produce identical canonical output" contract. UP is the *default* backend for non-numeric domains, so this affected the default trajectory output. Now emits the canonical s-expression form with the domain-resolved name **and** arguments (`canonicalize_action(schema.name, [o.name for o in param_objects])`). Verified identical across functional / s-expr / bare / mixed-case inputs.

- **pddl-validator 3.0.1 (HIGH)** — `get_state_transition` dropped `status`, so a `STRUCTURE_ERROR`/`SYNTAX_ERROR` returned `{"valid": false, "steps": [], "trajectory": []}` — indistinguishable from a plan that executed and failed. Now always includes `status`, matching the `validate_*` family.

- **pddl-validator tests (CRITICAL)** — `test_malformed_pddl` used `... or status == "SYNTAX_ERROR"`, which short-circuits to pass whenever no exception-`error` key exists; the input `(define (domain broken))` was also a valid empty domain. Switched to genuinely malformed input (unbalanced parens) asserting rejection as `SYNTAX_ERROR`.

- **pddl-validator 3.0.1 — cherry-pick from #56 (HIGH, low-risk)** — a numeric plan referencing an uninitialized fluent made pyvalidator raise, so `validate_plan` / `get_state_transition` returned a generic `{"error": true}` instead of a verdict (reproduced on `main`). Now re-shaped into `{"valid": false, "status": "PRECONDITION_ERROR", ...}` via a narrow substring match that falls back to the generic envelope if the upstream message changes. Additive; no success-path change.

Guard tests added: cross-backend canonical-action (mixed-case), structure-error `status`, and uninitialized-fluent `PRECONDITION_ERROR` (both tools).

> **Not cherry-picked from #56:** the FastMCP structured-arg-error wrapper (the bulk of #56, ~280 duplicated lines, unproven lift), plan-input flexibility, and solver `log_tail` — higher complexity / not high-impact-low-risk.

> **Disproven review item:** a 4th finding (divergent invalid-plan handling between backends) was investigated and dropped — pddl-plus's `Operator.apply(allow_inapplicable_actions=False)` raises, so both backends already error out on inapplicable actions.

## Versioning
- pddl-validator 3.0.0 → 3.0.1, pddl-parser 1.6.0 → 1.6.1 (plugin.json + both marketplace.json + CHANGELOG).

## Test plan

- [x] `plugins/pddl-validator/tests/verify.py` — 24/24
- [x] `plugins/pddl-parser/tests/verify.py` — 45/45
- [x] `tests/static_checks.py`
- [x] `tests/mcp_protocol_test.py`