### PR TITLE
Add pddl-visualizer plugin (pure skill) + worked example

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PDDL planning and validation tools for Claude Code",
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "plugins": [
     {
@@ -63,6 +63,20 @@
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
       "category": "planning",
       "keywords": ["pddl", "authoring", "domain-design", "natural-language", "iterative-fix"]
+    },
+    {
+      "name": "pddl-visualizer",
+      "description": "Turn a PDDL plan into a single self-contained, animated HTML visualization — step through the trajectory in any browser, no server. Pure skill, no MCP server.",
+      "author": {
+        "name": "SPL-BGU"
+      },
+      "license": "MIT",
+      "version": "0.1.0",
+      "source": "./plugins/pddl-visualizer",
+      "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+      "repository": "https://github.com/SPL-BGU/pddl-copilot",
+      "category": "planning",
+      "keywords": ["pddl", "visualization", "animation", "trajectory", "explainability"]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "PDDL planning tools marketplace",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
@@ -64,6 +64,20 @@
       "repository": "https://github.com/SPL-BGU/pddl-copilot",
       "category": "planning",
       "keywords": ["pddl", "authoring", "domain-design", "natural-language", "iterative-fix"]
+    },
+    {
+      "name": "pddl-visualizer",
+      "description": "Turn a PDDL plan into a single self-contained, animated HTML visualization — step through the trajectory in any browser, no server. Pure skill, no MCP server.",
+      "author": {
+        "name": "SPL-BGU"
+      },
+      "license": "MIT",
+      "version": "0.1.0",
+      "source": "./plugins/pddl-visualizer",
+      "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+      "repository": "https://github.com/SPL-BGU/pddl-copilot",
+      "category": "planning",
+      "keywords": ["pddl", "visualization", "animation", "trajectory", "explainability"]
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This repository is a Claude Code plugin marketplace. Each plugin lives in its ow
 - **pddl-validator** (`plugins/pddl-validator/`) — PDDL validation and state transition simulation using pyvalidator. Pure pip, no Docker.
 - **pddl-parser** (`plugins/pddl-parser/`) — PDDL parsing and structured trajectory generation with dual-backend support: pddl-plus-parser (default) and unified-planning. Pure pip, no Docker.
 - **pddl-author** (`plugins/pddl-author/`) — Authoring and iterative-fix skills (no MCP server). Drafts PDDL from NL descriptions and fixes via sibling plugins as ground truth. Pure skill.
+- **pddl-visualizer** (`plugins/pddl-visualizer/`) — Turns a domain + problem + plan into a single self-contained, animated HTML visualization. Reuses pddl-parser for ground-truth states. Pure skill, no MCP server.
 
 ## Examples (not part of the maintained surface)
 

--- a/plugins/pddl-visualizer/.claude-plugin/plugin.json
+++ b/plugins/pddl-visualizer/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pddl-visualizer",
+  "version": "0.1.0",
+  "description": "Turn a PDDL plan into a single self-contained, animated HTML visualization. Reuses pddl-parser for ground-truth states and pddl-solver to obtain a plan. Pure skill, no MCP server.",
+  "author": {
+    "name": "SPL-BGU"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/SPL-BGU/pddl-copilot",
+  "repository": "https://github.com/SPL-BGU/pddl-copilot",
+  "keywords": ["pddl", "visualization", "animation", "trajectory", "explainability"]
+}

--- a/plugins/pddl-visualizer/CLAUDE.md
+++ b/plugins/pddl-visualizer/CLAUDE.md
@@ -1,0 +1,20 @@
+# PDDL Visualizer — Plugin Rules
+
+PDDL plan visualization plugin. Pure skill (no MCP server, no Python deps). Turns a domain + problem + plan into a single self-contained HTML file that animates the plan step-by-step. Orchestrates the sibling plugins `pddl-parser` (ground-truth states) and `pddl-solver` (to obtain a plan) — does not import their code.
+
+One skill:
+- `pddl-visualizing` — given a domain, a problem, and a plan (or a request to plan one first), produce a standalone animated HTML visualization of the resulting trajectory.
+
+## Dependencies (runtime)
+
+This skill calls MCP tools from sibling plugins. They are **soft dependencies** — the skill detects missing tools and reports them to the user rather than failing silently or inventing state. For full functionality, install:
+
+- `pddl-parser` (required) — `get_trajectory`, `inspect_domain`, `inspect_problem`. Supplies the true state at each plan step. The skill MUST NOT hand-simulate states.
+- `pddl-solver` (recommended) — `classic_planner`, `numeric_planner`. Used only when the user has no plan yet and asks to generate one before visualizing.
+
+The visualizer plugin itself ships zero binaries and zero Python deps. Its only output is an HTML file written to disk.
+
+## Scope boundaries
+
+- **In scope**: rendering a known plan/trajectory as a single self-contained, animated HTML file that opens in any browser with no server, build step, or network access.
+- **Out of scope**: running a live web app or server, computing plans (that is `pddl-solver`), proving plan validity (that is `pddl-validator`), and benchmarking or batch evaluation across many domains. Those belong elsewhere — this repo is functional implementation only.

--- a/plugins/pddl-visualizer/examples/README.md
+++ b/plugins/pddl-visualizer/examples/README.md
@@ -1,0 +1,26 @@
+# Example — logistics plan visualization
+
+A worked end-to-end output of the `pddl-visualizing` skill.
+
+- **`domain.pddl` / `problem.pddl` / `plan.solution`** — a tiny logistics instance: a truck `t1` carries package `p1` from `B` to `C` over roads `A–B–C`.
+- **`logistics-plan.html`** — the generated visualization. Open it in any browser (double-click); no server, build step, or network needed.
+
+## How it was produced
+
+1. The plan's per-step states came from `pddl-parser`'s `get_trajectory(domain, problem, plan)` — the skill never hand-simulates state. (`parser_used: unified-planning`, 4 steps.)
+2. Each returned state became one frame `{ action, facts, added, removed }`, with `added`/`removed` diffed against the previous frame.
+3. The scene mapping: `location → node`, `(road ?a ?b) → edge`, `(at ?o ?l) → place ?o on node ?l`, `(in ?p ?t) → package rides on the truck`.
+
+## Regenerate
+
+```bash
+# from repo root, with pddl-parser installed
+python3 -c "
+import sys; sys.path.insert(0, 'plugins/pddl-parser/server')
+import parser_server as ps, json
+fn = getattr(ps.get_trajectory, 'fn', ps.get_trajectory)
+print(json.dumps(fn('plugins/pddl-visualizer/examples/domain.pddl',
+                     'plugins/pddl-visualizer/examples/problem.pddl',
+                     'plugins/pddl-visualizer/examples/plan.solution'), indent=2))
+"
+```

--- a/plugins/pddl-visualizer/examples/README.md
+++ b/plugins/pddl-visualizer/examples/README.md
@@ -1,6 +1,6 @@
 # Example — logistics plan visualization
 
-A worked end-to-end output of the `pddl-visualizing` skill.
+A worked end-to-end output of the `pddl-visualizing` skill, rendered in **themed mode** (bespoke logistics SVG — trucks and packages drawn at location nodes). Generic mode is the skill's domain-agnostic default; it keeps the same per-step fact panel but draws plain nodes/edges/badges for any domain.
 
 - **`domain.pddl` / `problem.pddl` / `plan.solution`** — a tiny logistics instance: a truck `t1` carries package `p1` from `B` to `C` over roads `A–B–C`.
 - **`logistics-plan.html`** — the generated visualization. Open it in any browser (double-click); no server, build step, or network needed.
@@ -21,6 +21,11 @@ import parser_server as ps, json
 fn = getattr(ps.get_trajectory, 'fn', ps.get_trajectory)
 print(json.dumps(fn('plugins/pddl-visualizer/examples/domain.pddl',
                      'plugins/pddl-visualizer/examples/problem.pddl',
-                     'plugins/pddl-visualizer/examples/plan.solution'), indent=2))
+                     'plugins/pddl-visualizer/examples/plan.solution',
+                     parser='unified-planning'), indent=2))
 "
 ```
+
+## Why this example is classic, not numeric
+
+The renderer's frame model is **boolean-only** — `{ action, facts, added, removed }`. It draws predicate state (nodes, edges, badges, fact diff) and has no field for numeric fluent *values*. `numeric_planner` is wired into the skill only to *obtain* a plan for numeric/PDDL 2.1 domains, and `get_trajectory` can trace them — but a numeric domain would render its relational structure while silently dropping its numbers (fuel, cost, etc.). This example is plain STRIPS so that what you see is exactly what the renderer models.

--- a/plugins/pddl-visualizer/examples/domain.pddl
+++ b/plugins/pddl-visualizer/examples/domain.pddl
@@ -1,0 +1,19 @@
+(define (domain logistics)
+  (:requirements :typing)
+  (:types truck package location - object)
+  (:predicates
+    (at ?x - object ?l - location)
+    (in ?p - package ?t - truck)
+    (road ?l1 - location ?l2 - location))
+  (:action drive
+    :parameters (?t - truck ?from - location ?to - location)
+    :precondition (and (at ?t ?from) (road ?from ?to))
+    :effect (and (not (at ?t ?from)) (at ?t ?to)))
+  (:action load
+    :parameters (?p - package ?t - truck ?l - location)
+    :precondition (and (at ?p ?l) (at ?t ?l))
+    :effect (and (not (at ?p ?l)) (in ?p ?t)))
+  (:action unload
+    :parameters (?p - package ?t - truck ?l - location)
+    :precondition (and (in ?p ?t) (at ?t ?l))
+    :effect (and (not (in ?p ?t)) (at ?p ?l))))

--- a/plugins/pddl-visualizer/examples/logistics-plan.html
+++ b/plugins/pddl-visualizer/examples/logistics-plan.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PDDL plan — logistics-1</title>
+<style>
+  :root { --bg:#0f1420; --panel:#1a2233; --ink:#e7ecf5; --muted:#8aa0c0;
+          --edge:#39507a; --node:#2b3a5c; --truck:#3b82f6; --pkg:#f59e0b;
+          --add:#22c55e; --del:#ef4444; }
+  * { box-sizing:border-box; }
+  body { margin:0; font:15px/1.5 system-ui,Segoe UI,Roboto,sans-serif;
+         background:var(--bg); color:var(--ink); }
+  header { padding:14px 20px; border-bottom:1px solid #243049; }
+  header h1 { margin:0; font-size:17px; }
+  header .sub { color:var(--muted); font-size:13px; margin-top:2px; }
+  main { display:flex; flex-wrap:wrap; gap:16px; padding:16px 20px; }
+  .stage { flex:1 1 520px; background:var(--panel); border-radius:12px; padding:8px; }
+  svg { width:100%; height:auto; display:block; }
+  .side { flex:0 0 280px; background:var(--panel); border-radius:12px; padding:14px; }
+  .controls { display:flex; align-items:center; gap:8px; padding:8px 4px 14px; }
+  button { background:var(--node); color:var(--ink); border:1px solid var(--edge);
+           border-radius:8px; padding:7px 12px; font-size:14px; cursor:pointer; }
+  button:hover { background:#34466e; }
+  .counter { color:var(--muted); margin-left:auto; font-variant-numeric:tabular-nums; }
+  .action { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:15px;
+            padding:8px 10px; background:#11192a; border-radius:8px; border:1px solid #243049; }
+  .action .lbl { color:var(--muted); font-family:system-ui; font-size:12px; display:block; }
+  h2 { font-size:12px; text-transform:uppercase; letter-spacing:.06em; color:var(--muted);
+       margin:16px 0 8px; }
+  ul { list-style:none; margin:0; padding:0; }
+  li { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:13px;
+       padding:2px 0; color:var(--ink); }
+  li.add { color:var(--add); }
+  li.del { color:var(--del); text-decoration:line-through; opacity:.8; }
+</style>
+</head>
+<body>
+<header>
+  <h1>logistics-1 — plan visualization</h1>
+  <div class="sub">4 steps · states from pddl-parser <code>get_trajectory</code> (unified-planning) · self-contained, no server</div>
+</header>
+
+<main>
+  <div class="stage">
+    <div class="controls">
+      <button id="prev">◀ Prev</button>
+      <button id="play">▶ Play</button>
+      <button id="next">Next ▶</button>
+      <span class="counter" id="counter"></span>
+    </div>
+    <svg viewBox="0 0 800 320" id="scene" aria-label="plan scene"></svg>
+  </div>
+  <div class="side">
+    <div class="action"><span class="lbl">action applied</span><span id="action"></span></div>
+    <h2>State (true facts)</h2>
+    <ul id="facts"></ul>
+  </div>
+</main>
+
+<script>
+// Frames built mechanically from get_trajectory output (states are ground truth,
+// never hand-simulated). Each frame: the state's true facts plus the diff vs. the
+// previous frame, and the action that produced it.
+const FRAMES = [
+ {action:"(initial state)", facts:["(at p1 b)","(at t1 a)","(road a b)","(road b a)","(road b c)","(road c b)"], added:[], removed:[]},
+ {action:"(drive t1 a b)",  facts:["(at p1 b)","(at t1 b)","(road a b)","(road b a)","(road b c)","(road c b)"], added:["(at t1 b)"], removed:["(at t1 a)"]},
+ {action:"(load p1 t1 b)",  facts:["(at t1 b)","(in p1 t1)","(road a b)","(road b a)","(road b c)","(road c b)"], added:["(in p1 t1)"], removed:["(at p1 b)"]},
+ {action:"(drive t1 b c)",  facts:["(at t1 c)","(in p1 t1)","(road a b)","(road b a)","(road b c)","(road c b)"], added:["(at t1 c)"], removed:["(at t1 b)"]},
+ {action:"(unload p1 t1 c)",facts:["(at p1 c)","(at t1 c)","(road a b)","(road b a)","(road b c)","(road c b)"], added:["(at p1 c)"], removed:["(in p1 t1)"]},
+];
+
+// Scene mapping (the visual contract):
+//   location -> node ; (road ?a ?b) -> edge ; (at ?o ?l) -> place ?o on node ?l ;
+//   (in ?p ?t) -> draw ?p as a badge riding on truck ?t.
+const LOC = { a:{x:150,y:200}, b:{x:400,y:200}, c:{x:650,y:200} };
+const SVGNS = "http://www.w3.org/2000/svg";
+const scene = document.getElementById("scene");
+let i = 0, timer = null;
+
+function parse(fact){ const m = fact.match(/\(([\w-]+)([^)]*)\)/); return m ? [m[1], m[2].trim().split(/\s+/).filter(Boolean)] : [null,[]]; }
+function el(tag, attrs, text){ const e = document.createElementNS(SVGNS, tag);
+  for(const k in attrs) e.setAttribute(k, attrs[k]); if(text!=null) e.textContent = text; return e; }
+
+function drawNode(p, label){
+  scene.appendChild(el("circle", {cx:p.x, cy:p.y, r:42, fill:"var(--node)", stroke:"var(--edge)", "stroke-width":2}));
+  scene.appendChild(el("text", {x:p.x, y:p.y+6, "text-anchor":"middle", "font-size":22, fill:"var(--ink)", "font-weight":700}, label));
+}
+function drawTruck(p, carrying){
+  const x = p.x, y = p.y-78;
+  scene.appendChild(el("rect", {x:x-34, y:y-22, width:68, height:40, rx:8, fill:"var(--truck)"}));
+  scene.appendChild(el("text", {x:x, y:y+4, "text-anchor":"middle", "font-size":18, fill:"#fff", "font-weight":700}, "t1 🚚"));
+  if(carrying){ scene.appendChild(el("rect", {x:x+18, y:y-34, width:26, height:22, rx:5, fill:"var(--pkg)"}));
+                scene.appendChild(el("text", {x:x+31, y:y-18, "text-anchor":"middle", "font-size":12, fill:"#111", "font-weight":700}, "p1")); }
+}
+function drawPackage(p){
+  const x = p.x, y = p.y+82;
+  scene.appendChild(el("rect", {x:x-22, y:y-18, width:44, height:36, rx:7, fill:"var(--pkg)"}));
+  scene.appendChild(el("text", {x:x, y:y+5, "text-anchor":"middle", "font-size":16, fill:"#111", "font-weight":700}, "p1 📦"));
+}
+
+function render(){
+  while(scene.firstChild) scene.removeChild(scene.firstChild);
+  const f = FRAMES[i];
+
+  // static edges from (road ...) — dedupe undirected pairs
+  const seen = new Set();
+  for(const fact of f.facts){ const [n,a] = parse(fact);
+    if(n==="road"){ const key = [a[0],a[1]].sort().join("-"); if(seen.has(key)) continue; seen.add(key);
+      const p=LOC[a[0]], q=LOC[a[1]];
+      scene.appendChild(el("line", {x1:p.x, y1:p.y, x2:q.x, y2:q.y, stroke:"var(--edge)", "stroke-width":4})); } }
+
+  for(const k in LOC) drawNode(LOC[k], k.toUpperCase());
+
+  // movable objects
+  let truckLoc=null, pkgLoc=null, carried=false;
+  for(const fact of f.facts){ const [n,a]=parse(fact);
+    if(n==="at" && a[0]==="t1") truckLoc=a[1];
+    if(n==="at" && a[0]==="p1") pkgLoc=a[1];
+    if(n==="in" && a[0]==="p1") carried=true; }
+  if(truckLoc) drawTruck(LOC[truckLoc], carried);
+  if(pkgLoc && !carried) drawPackage(LOC[pkgLoc]);
+
+  // side panel
+  document.getElementById("action").textContent = f.action;
+  document.getElementById("counter").textContent = "step " + i + " / " + (FRAMES.length-1);
+  const ul = document.getElementById("facts"); ul.innerHTML = "";
+  for(const fact of f.facts){ const li=document.createElement("li");
+    li.textContent = fact; if(f.added.includes(fact)) li.className="add"; ul.appendChild(li); }
+  for(const fact of f.removed){ const li=document.createElement("li");
+    li.textContent = fact; li.className="del"; ul.appendChild(li); }
+}
+
+function go(n){ i = Math.max(0, Math.min(FRAMES.length-1, n)); render(); }
+function stop(){ if(timer){ clearInterval(timer); timer=null; document.getElementById("play").textContent="▶ Play"; } }
+document.getElementById("prev").onclick = ()=>{ stop(); go(i-1); };
+document.getElementById("next").onclick = ()=>{ stop(); go(i+1); };
+document.getElementById("play").onclick = ()=>{
+  if(timer){ stop(); return; }
+  if(i>=FRAMES.length-1) i=0;
+  document.getElementById("play").textContent="⏸ Pause";
+  timer = setInterval(()=>{ if(i>=FRAMES.length-1){ stop(); return; } go(i+1); }, 1100);
+};
+render();
+</script>
+</body>
+</html>

--- a/plugins/pddl-visualizer/examples/plan.solution
+++ b/plugins/pddl-visualizer/examples/plan.solution
@@ -1,0 +1,4 @@
+(drive t1 a b)
+(load p1 t1 b)
+(drive t1 b c)
+(unload p1 t1 c)

--- a/plugins/pddl-visualizer/examples/problem.pddl
+++ b/plugins/pddl-visualizer/examples/problem.pddl
@@ -1,0 +1,5 @@
+(define (problem logistics-1)
+  (:domain logistics)
+  (:objects t1 - truck p1 - package a b c - location)
+  (:init (at t1 a) (at p1 b) (road a b) (road b a) (road b c) (road c b))
+  (:goal (at p1 c)))

--- a/plugins/pddl-visualizer/skills/pddl-visualizing/SKILL.md
+++ b/plugins/pddl-visualizer/skills/pddl-visualizing/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: pddl-visualizing
+description: Use when the user asks to visualize, animate, draw, render, or "see" a PDDL plan or trajectory — to turn a domain + problem + plan into a standalone animated HTML file that shows each step. NOT for computing a plan (use pddl-solver) or proving validity (use pddl-validator).
+allowed-tools: Write, mcp__pddl-parser__get_trajectory, mcp__pddl-parser__inspect_domain, mcp__pddl-parser__inspect_problem, mcp__pddl-solver__classic_planner, mcp__pddl-solver__numeric_planner
+---
+
+## CRITICAL RULES — zero exceptions
+
+### You MUST NOT hand-simulate states — get them from the parser
+
+LLMs cannot reliably track predicate sets through an action sequence. The state at each step MUST come from `get_trajectory(domain, problem, plan)` (pddl-parser). Never guess, simulate, or "fill in" a state yourself. Every frame in the output is built from a state the parser returned — nothing else.
+
+If `pddl-parser` is not installed, **stop** and tell the user. Do not produce a visualization from invented state.
+
+### The output is ONE self-contained file that opens offline
+
+The deliverable is a single `.html` file with **all** CSS and JS inline. No server, no build step, no CDN, no `<script src=...>`, no network access. It must render by double-clicking the file in any browser. No React/Vue/D3/external frameworks — plain inline JS + SVG only.
+
+### You visualize the trajectory; you do not judge it
+
+Render exactly what the trajectory reports. Do not claim the plan is "valid", "optimal", or "correct" — that is `pddl-validator`'s job. `get_trajectory` **assumes the plan is valid** and returns no per-step verdict; if it errors, treat the plan as invalid — stop, say so, and suggest the user validate it with `pddl-validator` (`validate_plan` / `get_state_transition`) first. Never invent frames to paper over an error.
+
+## Workflow
+
+1. **Obtain the plan.**
+   - If the user supplied a plan, use it verbatim.
+   - If they have only a domain + problem and want a plan first: if `pddl-solver` is available, call `classic_planner` (or `numeric_planner` for numeric/PDDL 2.1 domains) and use the returned plan. If the solver is not installed, ask the user to provide a plan or install `pddl-solver`.
+
+2. **Get the ground-truth trajectory.** Call `get_trajectory(domain, problem, plan)`. This returns the state before/after each action — the single source of truth for every frame. It assumes the plan is valid; if it returns an error, do not guess — report that the plan appears invalid and suggest validating it with `pddl-validator` first.
+
+3. **Read structure for layout.** Call `inspect_problem` (objects, init) and `inspect_domain` (predicates with arities, types) so you know the node set and which predicates are unary/binary.
+
+4. **Propose a one-screen scene mapping** (the visual contract) — a compact table the user can audit:
+   - Which objects become **nodes**.
+   - Which **binary** predicates become labeled **edges** (e.g. `(connected ?a ?b)`, `(road-between ?a ?b)`).
+   - Which **unary** predicates become node **badges/state** (e.g. `(holding ?x)`, `(clear ?x)`).
+   - Which predicate positions a movable object (e.g. `(at ?obj ?loc)` places `?obj` on the `?loc` node).
+
+   Default to **Generic mode** (below). Show the mapping and proceed unless the user redirects you — one turn, not an interview.
+
+5. **Generate the HTML** per the output spec below, embedding the trajectory frames, and **Write** it to disk. Default path: alongside the problem file as `<problem-stem>-plan.html`, or wherever the user asks.
+
+6. **Report**: the file path, a one-line "open this in your browser" instruction, the mapping used, and the number of steps.
+
+## Tools you may call
+
+All accept inline PDDL content **or** an absolute file path.
+
+- `get_trajectory(domain, problem, plan, parser?)` (pddl-parser) — the state before/after each action; the source of every frame. `plan` may be a list of action strings, a newline-separated string, or a path. **Assumes the plan is valid** — no per-step verdict, so if it errors, treat the plan as invalid (see step 2).
+- `inspect_domain(domain, problem?, parser?)` (pddl-parser) — predicates (with arities), types, actions. Use to tell unary predicates (badges) from binary ones (edges).
+- `inspect_problem(domain, problem, parser?)` (pddl-parser) — objects and initial state; your node set.
+- `classic_planner(domain, problem, strategy?)` (pddl-solver) — compute a plan when the user has none and the domain has no `:functions`.
+- `numeric_planner(domain, problem, ...)` (pddl-solver) — same, for numeric/PDDL 2.1 domains (those declaring `:functions`).
+
+## Two render modes
+
+**Generic mode (default — always works).** Mechanical and domain-agnostic, so it renders *something* correct for any domain:
+- Objects are SVG nodes (circle/grid/force-free layout).
+- Binary predicates that currently hold are labeled edges between their two object nodes.
+- Unary predicates that hold are badges on the node.
+- A side panel lists every true fact for the current step, with facts **added** by the last action highlighted and facts **removed** shown struck through (computed from the previous frame's state).
+
+**Themed mode (optional — only when asked or obviously applicable).** Bespoke SVG for a familiar domain (e.g. blocks stacked into towers for blocksworld; trucks/packages drawn at location nodes for logistics; a robot gripper for gripper). Keep the same per-step fact panel as a fallback so no information is lost if the bespoke layout misses a predicate.
+
+## Output spec — the generated HTML MUST contain
+
+1. **Embedded data**: a JS array of frames built from `get_trajectory`. One frame per step, e.g.
+   `{ step, action, facts: [...], added: [...], removed: [...] }` — `facts` are that step's true facts; `added`/`removed` are the diff vs. the previous frame.
+2. **Controls**: `◀ Prev`, `▶ Play / Pause` (autoplay ~1 step/sec), `Next ▶`, a step counter (`step i / N`), and the current **action label**.
+3. **A render area** (SVG) drawn from the current frame's facts per the chosen mode.
+4. **A fact panel** showing the current state with added/removed highlighting.
+5. **Honest length**: include exactly the frames `get_trajectory` returned — never pad or truncate. (An invalid plan is caught in step 2, before any HTML is generated.)
+
+Keep it small and readable — one `<style>` block, one `<script>` block, no minification.
+
+## If a sibling plugin's tool is missing
+
+- **`pddl-parser` (`get_trajectory`) missing** → stop:
+  > "I can't get the true state at each step without `pddl-parser` (`get_trajectory`), and I won't guess states. Install `pddl-parser` and re-run."
+- **`pddl-solver` missing and no plan supplied** → ask the user to provide a plan or install `pddl-solver`. Do not invent a plan.
+
+## Worked example (Generic mode, compressed)
+
+User: *"Visualize this plan for my logistics domain."* (supplies domain, problem, and a plan: `drive t1 A B`, `load p1 t1 B`, `drive t1 B C`, `unload p1 t1 C`).
+
+1. `get_trajectory(domain, problem, plan)` → 4 actions, 5 states; trajectory completes.
+2. `inspect_problem` → objects `t1, p1, A, B, C`; `inspect_domain` → predicates `(at ?x ?l)` [binary, positions], `(in ?p ?t)` [binary, badge], `(road-between ?l1 ?l2)` [binary, edge].
+3. Mapping shown:
+
+   | predicate | role |
+   |---|---|
+   | `road-between` | static edge between location nodes |
+   | `at` | place object on its location node |
+   | `in` | badge "in t1" on the package |
+
+4. Generate `logistics-plan.html` with 5 frames; each frame highlights the diff (e.g. step 2 adds `(in p1 t1)`, removes `(at p1 B)`).
+5. Report: `logistics-plan.html` written — open it in a browser; 4 steps; trajectory completed.
+
+## What you MUST NOT do
+
+- Do NOT hand-simulate, guess, or "correct" states — every frame comes from `get_trajectory`.
+- Do NOT claim the plan is valid/optimal/correct — that is `pddl-validator`'s job.
+- Do NOT emit anything that needs a server, build, CDN, or network — one offline file only.
+- Do NOT pad, truncate, or fabricate frames — emit exactly what `get_trajectory` returned.
+- Do NOT pull in external JS frameworks — plain inline JS + SVG.

--- a/plugins/pddl-visualizer/skills/pddl-visualizing/SKILL.md
+++ b/plugins/pddl-visualizer/skills/pddl-visualizing/SKILL.md
@@ -60,7 +60,9 @@ All accept inline PDDL content **or** an absolute file path.
 - Unary predicates that hold are badges on the node.
 - A side panel lists every true fact for the current step, with facts **added** by the last action highlighted and facts **removed** shown struck through (computed from the previous frame's state).
 
-**Themed mode (optional — only when asked or obviously applicable).** Bespoke SVG for a familiar domain (e.g. blocks stacked into towers for blocksworld; trucks/packages drawn at location nodes for logistics; a robot gripper for gripper). Keep the same per-step fact panel as a fallback so no information is lost if the bespoke layout misses a predicate.
+**Themed mode (optional — only when asked or obviously applicable).** Bespoke SVG for a familiar domain (e.g. blocks stacked into towers for blocksworld; trucks/packages drawn at location nodes for logistics; a robot gripper for gripper). Keep the same per-step fact panel as a fallback so no information is lost if the bespoke layout misses a predicate. (The bundled `examples/logistics-plan.html` is themed mode.)
+
+**Numeric domains.** The frame model carries boolean facts only — it does **not** render numeric fluent *values* (fuel, cost, etc.). You may still visualize a numeric/PDDL 2.1 domain's relational structure, but say plainly that numeric values are not shown; never fabricate numeric readouts.
 
 ## Output spec — the generated HTML MUST contain
 
@@ -70,6 +72,7 @@ All accept inline PDDL content **or** an absolute file path.
 3. **A render area** (SVG) drawn from the current frame's facts per the chosen mode.
 4. **A fact panel** showing the current state with added/removed highlighting.
 5. **Honest length**: include exactly the frames `get_trajectory` returned — never pad or truncate. (An invalid plan is caught in step 2, before any HTML is generated.)
+6. **Text-safe embedding**: inject object/predicate names as text (`textContent` or SVG text nodes), never via `innerHTML` or raw template interpolation, so an unusual identifier can't break the markup.
 
 Keep it small and readable — one `<style>` block, one `<script>` block, no minification.
 


### PR DESCRIPTION
## Summary

Adds a fifth marketplace plugin, **`pddl-visualizer`** — a Tier‑1 **pure skill** (no MCP server, no Python deps) that turns a PDDL domain + problem + plan into a single self-contained, animated **HTML** file that opens offline in any browser.

This is a clean-room adaptation of the [`planning-visualizer`](https://github.com/Diabhsn3/planning-visualizer) university project. That project is a full web app (React + Node/Express + tRPC, Python/Fast Downward, runtime-compiled TypeScript renderers). We keep only its one novel idea — *LLM-generated, domain-specific visualizers* — and re-express it within this marketplace's model. **No upstream code is reused.**

## Design (why a pure skill)

- **No backend, no server, no build.** The agent generates the HTML directly; output is one offline file (inline SVG + JS). This is the deliberate simplification of the source app's multi-service stack.
- **Reuses sibling plugins as soft dependencies, no cross-plugin imports:**
  - `pddl-parser` `get_trajectory` → ground-truth state at each step (the skill **never** hand-simulates state).
  - `pddl-solver` `classic_planner` / `numeric_planner` → obtain a plan when the user has none.
- **Generic graph mode** renders any domain (objects → nodes, binary predicates → edges, unary → badges, per-step fact diff); optional **themed mode** for familiar domains (blocksworld, logistics, gripper).
- Mirrors the existing pure-skill plugin `pddl-author` in structure and conventions.

## Worked example

`plugins/pddl-visualizer/examples/` contains a tiny logistics instance and the generated `logistics-plan.html`. Its per-step states were produced by `pddl-parser`'s `get_trajectory` (`unified-planning` backend, 4 steps) — not hand-written — and the README documents how to regenerate.

## Correctness note

While wiring the skill I verified the real `get_trajectory` contract: it *assumes the plan is valid and returns no per-step verdict*. The skill reflects this — an invalid plan makes the tool error, at which point it stops and defers to `pddl-validator` rather than fabricating frames.

## Footprint

- New: `plugins/pddl-visualizer/{.claude-plugin/plugin.json, CLAUDE.md, skills/pddl-visualizing/SKILL.md}` + `examples/`
- Edited: both marketplace catalogs (entry + `metadata 1.5.0 → 1.6.0`), root `CLAUDE.md` listing
- Skills-only plugin → correctly omits `.mcp.json` / `.claude/settings.json` / `tests/`

## Verification

- `tests/static_checks.py` → **all checks pass**
- Embedded JS in the example → `node --check` clean
- Reviewed by the repo's `simplifier` agent; flagged items (unused `Read` perm, missing tool-signatures section, failure-handling framing) all addressed.

No license was reused from the upstream repo (it ships none); this is an independent implementation of the concept.

https://claude.ai/code/session_01Q3Gyj9LRouEoSzGzfBy6c4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3Gyj9LRouEoSzGzfBy6c4)_